### PR TITLE
fix(state): development export condition + CLAUDE.md commit rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,3 +146,7 @@ The framework includes built-in performance monitoring and optimization:
 - Ensure all tests pass before submitting PRs
 - Run `pnpm lint` and `pnpm format` on changes
 - Update documentation when changing APIs
+
+### Commits
+- Do **not** add `Co-Authored-By` trailers or any AI/assistant attribution to commit messages or PR descriptions.
+- Use Conventional Commits (`type(scope): subject`) — enforced by commitlint via the `commit-msg` hook.

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -5,11 +5,27 @@
   "type": "module",
   "main": "./dist/index.js",
   "exports": {
-    ".": "./dist/index.js",
-    "./reactive": "./dist/reactive-state.js",
-    "./persistence": "./dist/state-persistence.js",
-    "./validation": "./dist/state-validation.js",
-    "./manager": "./dist/state-manager.js"
+    ".": {
+      "types": "./types/index.d.ts",
+      "development": "./src/index.js",
+      "default": "./dist/index.js"
+    },
+    "./reactive": {
+      "development": "./src/reactive-state.js",
+      "default": "./dist/reactive-state.js"
+    },
+    "./persistence": {
+      "development": "./src/state-persistence.js",
+      "default": "./dist/state-persistence.js"
+    },
+    "./validation": {
+      "development": "./src/state-validation.js",
+      "default": "./dist/state-validation.js"
+    },
+    "./manager": {
+      "development": "./src/state-manager.js",
+      "default": "./dist/state-manager.js"
+    }
   },
   "keywords": [
     "coherent",


### PR DESCRIPTION
## Summary

Two small fixes rebased onto current `main`. This branch was reset onto `main` because `main` independently landed the pnpm 11 / CI / Node-matrix / allowBuilds work in parallel — so the earlier merge conflicts are gone and only the genuinely-missing pieces remain.

## Changes

- **fix(state):** `@coherent.js/state` `exports` pointed only at `./dist`, so importing the package failed whenever `dist` wasn't built (e.g. running tests against source). Added a `development → src` condition plus `types`, matching the other packages. Production resolution is unchanged (`default` → the same `dist` paths).
- **docs(claude):** add a `CLAUDE.md` rule — no `Co-Authored-By` trailers or AI attribution in commits/PRs; use Conventional Commits.

## Not included (separate effort)

`main` still has **1 critical + 15 high** audit findings (vitest, node-tar, vite, rollup…) and no `overrides:` block. That's a pre-existing, repo-wide security pass — the overrides need re-deriving against `main`'s current (restructured) tree, so it's best done on its own rather than bundled here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build configuration and development tooling to improve module export handling and enforce commit message standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->