### PR TITLE
Release guardrails: scaffold boot E2E, types-parity gate, void-element fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,9 @@ jobs:
         run: |
           for dir in packages/*/; do
             case "$dir" in *vscode-extension*) continue ;; esac
+            # Skip directories without a manifest (e.g. dist remnants of
+            # removed packages restored from the build cache).
+            [ -f "$dir/package.json" ] || continue
             echo "── publint $dir"
             pnpm dlx publint "$dir" || exit 1
           done

--- a/.github/workflows/scaffold-e2e.yml
+++ b/.github/workflows/scaffold-e2e.yml
@@ -1,0 +1,49 @@
+name: Scaffold Boot E2E
+
+# The gap that let rc.1 and rc.2 ship broken scaffolds: nothing installed,
+# typechecked, tested, and booted the projects `coherent create` produces.
+# This workflow runs scripts/scaffold-boot-e2e.mjs against the workspace
+# packages for representative permutations.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Nightly at 04:17 UTC
+    - cron: '17 4 * * *'
+  pull_request:
+    paths:
+      - 'packages/cli/**'
+      - 'packages/integrations/**'
+      - 'packages/core/**'
+      - 'packages/api/**'
+      - 'scripts/scaffold-boot-e2e.mjs'
+      - '.github/workflows/scaffold-e2e.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  scaffold-boot:
+    name: Scaffold, install, typecheck, test, boot
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm run build:packages
+
+      - name: Run scaffold boot E2E
+        run: node scripts/scaffold-boot-e2e.mjs

--- a/.github/workflows/scaffold-e2e.yml
+++ b/.github/workflows/scaffold-e2e.yml
@@ -1,10 +1,5 @@
 name: Scaffold Boot E2E
 
-# The gap that let rc.1 and rc.2 ship broken scaffolds: nothing installed,
-# typechecked, tested, and booted the projects `coherent create` produces.
-# This workflow runs scripts/scaffold-boot-e2e.mjs against the workspace
-# packages for representative permutations.
-
 on:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/scaffold-e2e.yml
+++ b/.github/workflows/scaffold-e2e.yml
@@ -24,6 +24,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "perf:gate": "node benchmarks/perf-gate.js",
     "test:node": "pnpm -r run test:node",
     "e2e": "playwright test",
+    "e2e:scaffold": "node scripts/scaffold-boot-e2e.mjs",
     "e2e:install": "playwright install --with-deps chromium",
     "e2e:report": "playwright show-report"
   },

--- a/packages/api/types/index.d.ts
+++ b/packages/api/types/index.d.ts
@@ -175,14 +175,34 @@ export interface RouterConfig {
   strict?: boolean;
 }
 
+/** Options accepted when registering a route */
+export interface RouteRegistrationOptions {
+  middleware?: Middleware[];
+  name?: string;
+  version?: string;
+}
+
 /** Object router interface */
 export interface ObjectRouter {
   routes: RouteObject;
   config: RouterConfig;
-  addRoute(path: string, definition: RouteDefinition): void;
+  addRoute(method: string, path: string, handler: RouteHandler, options?: RouteRegistrationOptions): void;
   addRoutes(routes: RouteObject): void;
+  get(path: string, handler: RouteHandler, options?: RouteRegistrationOptions): void;
+  post(path: string, handler: RouteHandler, options?: RouteRegistrationOptions): void;
+  put(path: string, handler: RouteHandler, options?: RouteRegistrationOptions): void;
+  patch(path: string, handler: RouteHandler, options?: RouteRegistrationOptions): void;
+  delete(path: string, handler: RouteHandler, options?: RouteRegistrationOptions): void;
   use(middleware: Middleware): void;
   use(path: string, middleware: Middleware): void;
+  /**
+   * Adapt the router to an Express router. Pass the express module itself;
+   * the returned value is whatever `express.Router()` produces, so it plugs
+   * straight into `app.use(path, router.toExpressRouter(express))`.
+   */
+  toExpressRouter<RouterType>(express: { Router: () => RouterType }): RouterType;
+  /** Create a bare node:http server that delegates every request to handle(). */
+  createServer(options?: Record<string, unknown>): import('http').Server;
   /**
    * Handle a raw Node request/response pair. The router parses query, params
    * and body itself, so a plain IncomingMessage is accepted.
@@ -482,14 +502,6 @@ export class NotFoundError extends ApiError {
  * Thrown when operation conflicts with current state (HTTP 409).
  */
 export class ConflictError extends ApiError {
-  constructor(message?: string);
-}
-
-/**
- * Bad request error class.
- * Thrown when request is malformed (HTTP 400).
- */
-export class BadRequestError extends ApiError {
   constructor(message?: string);
 }
 

--- a/packages/cli/src/generators/project-scaffold.js
+++ b/packages/cli/src/generators/project-scaffold.js
@@ -94,7 +94,8 @@ export async function scaffoldProject(projectPath, options) {
     port: 3000,
     hasApi: packages.includes('api') || auth,
     hasDatabase: !!database,
-    hasAuth: !!auth
+    hasAuth: !!auth,
+    isTypeScript
   });
   writeFileSync(join(projectPath, `src/index${fileExtension}`), serverContent);
 

--- a/packages/cli/src/generators/runtime-scaffold.js
+++ b/packages/cli/src/generators/runtime-scaffold.js
@@ -161,7 +161,7 @@ function matchRoute(routePattern, urlPath, requestMethod, routeMethod) {
  * Generate Express server setup
  */
 export function generateExpressServer(options = {}) {
-  const { port = 3000, hasApi = false, hasDatabase = false, hasAuth = false } = options;
+  const { port = 3000, hasApi = false, hasDatabase = false, hasAuth = false, isTypeScript = false } = options;
 
   const imports = [
     `import express from 'express';`,
@@ -216,7 +216,9 @@ app.get('/', (_req, res) => {
 });
 
 // Error handling (Express identifies error middleware by its 4-parameter signature)
-app.use((err, _req, res, _next) => {
+app.use((${isTypeScript
+    ? 'err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction'
+    : 'err, _req, res, _next'}) => {
   console.error(err.stack);
   res.status(500).send('Something broke!');
 });

--- a/packages/cli/types/index.d.ts
+++ b/packages/cli/types/index.d.ts
@@ -391,66 +391,9 @@ export interface Logger {
 // Main CLI Functions
 // ============================================================================
 
-/** Create a new project */
-export function createProject(options: CreateProjectOptions): Promise<void>;
-
-/** Generate component */
-export function generateComponent(options: GenerateComponentOptions): Promise<GenerationResult>;
-
-/** Generate page */
-export function generatePage(options: GeneratePageOptions): Promise<GenerationResult>;
-
-/** Generate API route */
-export function generateApi(options: GenerateApiOptions): Promise<GenerationResult>;
-
-/** Generate model */
-export function generateModel(options: GenerateModelOptions): Promise<GenerationResult>;
-
-/** Start development server */
-export function startDevServer(options?: Partial<DevServerConfig>): Promise<void>;
-
-/** Build project */
-export function buildProject(config?: Partial<BuildConfig>): Promise<void>;
-
-/** Run tests */
-export function runTests(options?: { watch?: boolean; coverage?: boolean }): Promise<void>;
-
-/** Lint project */
-export function lintProject(options?: { fix?: boolean }): Promise<void>;
-
-/** Format project */
-export function formatProject(): Promise<void>;
-
 // ============================================================================
 // CLI Utilities
 // ============================================================================
-
-/** Parse command line arguments */
-export function parseArgs(argv: string[]): { command: string; args: string[]; options: CLIOptions };
-
-/** Load project configuration */
-export function loadConfig(path?: string): Promise<CoherentConfig>;
-
-/** Save project configuration */
-export function saveConfig(config: CoherentConfig, path?: string): Promise<void>;
-
-/** Get project templates */
-export function getTemplates(): ProjectTemplate[];
-
-/** Get available generators */
-export function getGenerators(): CodeGenerator[];
-
-/** Create logger instance */
-export function createLogger(level?: 'debug' | 'info' | 'warn' | 'error'): Logger;
-
-/** Create file system utilities */
-export function createFileSystem(): FileSystem;
-
-/** Create plugin manager */
-export function createPluginManager(): PluginManager;
-
-/** Validate project structure */
-export function validateProject(path: string): Promise<ValidationResult>;
 
 // ============================================================================
 // Default Export

--- a/packages/core/src/rendering/html-renderer.js
+++ b/packages/core/src/rendering/html-renderer.js
@@ -372,6 +372,19 @@ class HTMLRenderer extends BaseRenderer {
             ? `<${tagName} ${attributeString}>`
             : `<${tagName}>`;
 
+        // Void elements take no closing tag and cannot have content (per the
+        // HTML spec); any text/children are dropped like a browser would.
+        if (isVoidElement(tagName)) {
+            if (options.enableCache && this.cache && RendererUtils.isCacheable(element, options)) {
+                const cacheKey = RendererUtils.generateCacheKey(tagName, element);
+                if (cacheKey) {
+                    this.cache.set(cacheKey, openingTag);
+                }
+            }
+            this.recordPerformance(tagName, startTime, false);
+            return openingTag;
+        }
+
         // Handle raw HTML injection (unescaped) — for SSR use cases like syntax highlighting
         if (_rawHtml !== undefined) {
             const rawContent = typeof _rawHtml === 'function' ? String(_rawHtml()) : String(_rawHtml);

--- a/packages/core/src/rendering/html-renderer.js
+++ b/packages/core/src/rendering/html-renderer.js
@@ -372,8 +372,7 @@ class HTMLRenderer extends BaseRenderer {
             ? `<${tagName} ${attributeString}>`
             : `<${tagName}>`;
 
-        // Void elements take no closing tag and cannot have content (per the
-        // HTML spec); any text/children are dropped like a browser would.
+        // Void elements: no closing tag; any text/children are dropped.
         if (isVoidElement(tagName)) {
             if (options.enableCache && this.cache && RendererUtils.isCacheable(element, options)) {
                 const cacheKey = RendererUtils.generateCacheKey(tagName, element);

--- a/packages/core/test/html-renderer.test.js
+++ b/packages/core/test/html-renderer.test.js
@@ -91,6 +91,36 @@ describe('HTML Renderer', () => {
     });
   });
 
+  describe('Void Elements', () => {
+    it('renders void elements with attributes and no closing tag', () => {
+      expect(render({ meta: { charset: 'utf-8' } })).toBe('<meta charset="utf-8">');
+      expect(render({ img: { src: 'x.png', alt: 'x' } })).toBe('<img src="x.png" alt="x">');
+      expect(render({ input: { type: 'text', name: 'q' } })).toBe('<input type="text" name="q">');
+      expect(render({ link: { rel: 'stylesheet', href: 'a.css' } })).toBe('<link rel="stylesheet" href="a.css">');
+    });
+
+    it('renders bare void elements without a closing tag', () => {
+      expect(render({ br: {} })).toBe('<br>');
+      expect(render({ hr: {} })).toBe('<hr>');
+    });
+
+    it('renders void elements correctly inside children', () => {
+      const html = render({
+        head: {
+          children: [
+            { meta: { charset: 'utf-8' } },
+            { title: { text: 'T' } }
+          ]
+        }
+      });
+      expect(html).toBe('<head><meta charset="utf-8"><title>T</title></head>');
+    });
+
+    it('drops content on void elements like a browser would', () => {
+      expect(render({ br: { text: 'ignored' } })).toBe('<br>');
+    });
+  });
+
   describe('Error Handling', () => {
     it('should throw errors for empty objects', () => {
       expect(() => render({})).toThrow('Invalid component structure');

--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -564,15 +564,6 @@ export function checkPeerDependencies(
 export function hasChildren(component: unknown): boolean;
 export function normalizeChildren(children: unknown): unknown[];
 
-/** Escape HTML characters in text */
-export function escapeHtml(text: string): string;
-
-/** Check if tag is a void element */
-export function isVoidElement(tagName: string): boolean;
-
-/** Format HTML attributes */
-export function formatAttributes(attrs: HTMLAttributes): string;
-
 /** Higher-order component for state management */
 export const withState: WithStateHOC;
 
@@ -581,15 +572,6 @@ export function memo<T extends (...args: any[]) => any>(
   fn: T,
   options?: MemoOptions
 ): MemoizedFunction<T>;
-
-/** Component memoization */
-export function memoComponent<P extends ComponentProps>(
-  component: CoherentComponent<P>,
-  options?: { propsEqual?: (a: P, b: P) => boolean; name?: string }
-): CoherentComponent<P>;
-
-/** Higher-order component for props transformation */
-export const withProps: WithPropsHOC;
 
 /** Validate component structure */
 export function validateComponent(obj: any, name?: string): boolean;
@@ -609,44 +591,9 @@ export function isLazy<T>(value: any): value is LazyWrapper<T>;
 /** Evaluate lazy values recursively */
 export function evaluateLazy<T>(obj: T, ...args: any[]): T;
 
-/** Create lazy component */
-export function lazyComponent<P extends ComponentProps>(
-  componentFactory: () => CoherentComponent<P>,
-  options?: LazyOptions
-): LazyWrapper<CoherentComponent<P>>;
-
 // ============================================================================
 // Component System Classes and Functions
 // ============================================================================
-
-/** Component class constructor */
-export class Component implements ComponentInstance {
-  constructor(definition?: ComponentDefinition);
-
-  name: string;
-  props: ComponentProps;
-  state: ComponentStateManager;
-  children: ComponentInstance[];
-  parent: ComponentInstance | null;
-  rendered: CoherentNode | null;
-  isMounted: boolean;
-  isDestroyed: boolean;
-  definition: ComponentDefinition;
-  hooks: Required<ComponentLifecycleHooks>;
-  methods: ComponentMethods;
-  computed: ComputedProperties;
-  computedCache: Map<string, any>;
-  watchers: ComponentWatchers;
-
-  render(props?: ComponentProps): CoherentNode;
-  mount(): ComponentInstance;
-  update(): ComponentInstance;
-  destroy(): ComponentInstance;
-  clone(overrides?: Partial<ComponentDefinition>): ComponentInstance;
-  getMetadata(): ComponentMetadata;
-  callHook(hookName: keyof ComponentLifecycleHooks, ...args: any[]): any;
-  handleError(error: Error, context?: string): void;
-}
 
 /** Create a component instance */
 export function createComponent(definition: ComponentDefinition | CoherentComponent): Component;
@@ -668,39 +615,9 @@ export function getComponent<P extends ComponentProps>(name: string): CoherentCo
 /** Get all registered components */
 export function getRegisteredComponents(): Map<string, CoherentComponent>;
 
-/** Create a higher-order component */
-export function createHOC<P extends ComponentProps, E extends ComponentProps>(
-  enhancer: (WrappedComponent: CoherentComponent<P>, props: E) => CoherentNode
-): (WrappedComponent: CoherentComponent<P>) => CoherentComponent<E>;
-
 // ============================================================================
 // State Management Functions
 // ============================================================================
-
-/** Create a state container */
-export function createState(initialState?: Record<string, any>): StateContainer;
-
-/** Global state manager instance */
-export const globalStateManager: GlobalStateManager;
-
-/** Provide context to children */
-export function provideContext<T>(key: string, value: T): void;
-
-/** Create a context provider component */
-export function createContextProvider<T>(
-  key: string,
-  value: T,
-  children: CoherentNode
-): ContextProvider;
-
-/** Restore context to previous value */
-export function restoreContext(key: string): void;
-
-/** Clear all context stacks */
-export function clearAllContexts(): void;
-
-/** Use context value */
-export function useContext<T>(key: string): T | undefined;
 
 // ============================================================================
 // Virtual DOM Types (Additional)
@@ -714,14 +631,6 @@ export interface VNode {
   key?: string | number;
 }
 
-/** VDOM operation types */
-export const VDOM_OPERATIONS: {
-  CREATE: string;
-  REMOVE: string;
-  REPLACE: string;
-  UPDATE: string;
-};
-
 /** VDOM patch operation */
 export interface VDOMPatch {
   type: string;
@@ -731,53 +640,13 @@ export interface VDOMPatch {
   props?: Record<string, any>;
 }
 
-/** Create a virtual node */
-export function createVNode(type: string | Function, props?: Record<string, any>, children?: VNode[]): VNode;
-
-/** Convert object to virtual node */
-export function objectToVNode(component: CoherentNode, depth?: number): VNode;
-
-/** Diff two virtual nodes */
-export function diff(oldVNode: VNode, newVNode: VNode, patches?: VDOMPatch[], path?: (string | number)[]): VDOMPatch[];
-
-/** Apply patches to DOM element */
-export function patch(element: HTMLElement, patches: VDOMPatch[]): void;
-
-/** VDOM differ class */
-export class VDOMDiffer {
-  diff(oldVNode: VNode, newVNode: VNode): VDOMPatch[];
-  patch(element: HTMLElement, patches: VDOMPatch[]): void;
-}
-
 // ============================================================================
 // CSS Management (Additional)
 // ============================================================================
 
-/** CSS manager for component styles */
-export class CSSManager {
-  addStyles(componentId: string, styles: string | Record<string, any>): void;
-  removeStyles(componentId: string): void;
-  getStyles(componentId?: string): string;
-  getAllStyles(): string;
-  clearStyles(): void;
-  hasStyles(componentId: string): boolean;
-}
-
 // ============================================================================
 // Performance Monitoring (Additional)
 // ============================================================================
-
-/** Performance monitor class */
-export class PerformanceMonitor {
-  startRender(id?: string): string;
-  endRender(id: string): number;
-  recordRender(type: string, duration: number, metadata?: any): void;
-  getMetrics(): Record<string, any>;
-  clearMetrics(): void;
-  enableMonitoring(): void;
-  disableMonitoring(): void;
-  isEnabled(): boolean;
-}
 
 /** Global performance monitor instance */
 export const performanceMonitor: PerformanceMonitor;
@@ -804,26 +673,9 @@ export interface CacheManager {
   prune(): void;
 }
 
-/** Create cache manager */
-export function createCacheManager(options?: CacheManagerOptions): CacheManager;
-
-/** Global cache manager instance */
-export const cacheManager: CacheManager;
-
 // ============================================================================
 // Bundle Optimization (Additional)
 // ============================================================================
-
-/** Bundle optimizer class */
-export class BundleOptimizer {
-  analyze(bundle: any): any;
-  optimize(bundle: any): any;
-  splitChunks(bundle: any): any[];
-  treeshake(bundle: any): any;
-}
-
-/** Global bundle optimizer instance */
-export const bundleOptimizer: BundleOptimizer;
 
 // ============================================================================
 // Component Cache (Additional)
@@ -849,9 +701,6 @@ export const VERSION: string;
 
 /** Composition utilities */
 export const compose: ComposeUtils;
-
-/** Component utilities */
-export const componentUtils: ComponentUtils;
 
 /** Default export with all core functionality */
 declare const coherent: {

--- a/packages/database/types/index.d.ts
+++ b/packages/database/types/index.d.ts
@@ -883,26 +883,12 @@ export function createDatabaseManager(config: DatabaseConfig): DatabaseManager;
 /** Create a connection */
 export function createConnection(config: DatabaseConfig): Promise<DatabaseConnection>;
 
-/**
- * Create a connection from database-specific configuration.
- * Provides better type inference for database-specific options.
- */
-export function createTypedConnection<T extends DatabaseSpecificConfig>(
-  config: T
-): Promise<DatabaseConnection>;
-
 /** Run migrations */
 export function runMigrations(
   connection: DatabaseConnection,
   migrations: Migration[],
   options?: { target?: string }
 ): Promise<MigrationStatus[]>;
-
-/** Database adapter creators */
-export function createPostgreSQLAdapter(config: PostgreSQLConfig | DatabaseConfig): DatabaseAdapter;
-export function createMySQLAdapter(config: MySQLConfig | DatabaseConfig): DatabaseAdapter;
-export function createSQLiteAdapter(config: SQLiteConfig | DatabaseConfig): DatabaseAdapter;
-export function createMongoDBAdapter(config: MongoDBConfig | DatabaseConfig): DatabaseAdapter;
 
 /** Middleware functions */
 export function withDatabase(options?: DatabaseMiddlewareOptions): any;

--- a/packages/devtools/types/index.d.ts
+++ b/packages/devtools/types/index.d.ts
@@ -412,27 +412,6 @@ export function measure<T>(name: string, fn: () => T): T;
  */
 export function profile<T>(fn: () => T): { result: T; duration: number };
 
-/**
- * Create a profiler that tracks render performance
- */
-export function createRenderProfiler(config?: ProfilerOptions): {
-  start(label: string): void;
-  end(label: string): number;
-  measure<T>(label: string, fn: () => T): T;
-  measureAsync<T>(label: string, fn: () => Promise<T>): Promise<T>;
-  getMetrics(): ProfileReport;
-  reset(): void;
-  onRender(callback: (result: ProfilerResult) => void): () => void;
-};
-
-/**
- * HOC to add profiling to a component
- */
-export function withProfiling<P extends ComponentProps>(
-  component: (props: P) => CoherentNode,
-  name?: string
-): (props: P) => CoherentNode;
-
 // ============================================================================
 // DevTools Configuration
 // ============================================================================
@@ -478,19 +457,6 @@ export interface DevToolsInstance {
   /** Check if enabled */
   isEnabled(): boolean;
 }
-
-/**
- * Create a devtools instance
- */
-export function createDevtools(config?: DevToolsConfig): DevToolsInstance;
-
-/**
- * HOC to add devtools tracking to a component
- */
-export function withDevtools<T extends (...args: unknown[]) => CoherentNode>(
-  component: T,
-  name?: string
-): T;
 
 // ============================================================================
 // DevTools Class

--- a/packages/forms/types/index.d.ts
+++ b/packages/forms/types/index.d.ts
@@ -199,11 +199,6 @@ export function createFormBuilder<T extends Record<string, unknown> = Record<str
 export function buildForm(config: FormConfig): CoherentNode;
 
 /**
- * Render a single form field
- */
-export function renderField<T = unknown>(field: FormField<T>): CoherentNode;
-
-/**
  * Validate a single field value
  * @returns Error message or null if valid
  */
@@ -386,24 +381,6 @@ export const validators: {
 // ============================================================================
 // Form Utilities
 // ============================================================================
-
-/**
- * Parse FormData to typed object
- */
-export function parseFormData<T extends Record<string, unknown>>(formData: FormData): T;
-
-/**
- * Serialize object to FormData
- */
-export function toFormData(data: Record<string, unknown>): FormData;
-
-/**
- * Create a form group (fieldset)
- */
-export function createFieldGroup(
-  legend: string,
-  fields: FormField[]
-): CoherentNode;
 
 // 1.0: removed deprecated SPA APIs — createForm, formValidators, enhancedForm,
 // createAsyncValidator, combineValidators, conditionalValidator.

--- a/packages/state/types/index.d.ts
+++ b/packages/state/types/index.d.ts
@@ -73,35 +73,9 @@ export type StoreMiddleware<T> = (
   payload?: unknown
 ) => T | void;
 
-/**
- * Create a typed state store
- */
-export function createStore<T extends Record<string, unknown>>(
-  options: StoreOptions<T>
-): Store<T>;
-
 // ============================================================================
 // Selector Types
 // ============================================================================
-
-/**
- * Create a derived selector from store state
- * @template T - Store state type
- * @template R - Return type of selector
- */
-export function createSelector<T extends Record<string, unknown>, R>(
-  store: Store<T>,
-  selector: (state: T) => R
-): () => R;
-
-/**
- * Create a memoized selector with dependencies
- */
-export function createMemoizedSelector<T extends Record<string, unknown>, D extends unknown[], R>(
-  store: Store<T>,
-  dependencies: (...args: D) => unknown[],
-  selector: (state: T, ...deps: D) => R
-): (...args: D) => R;
 
 // ============================================================================
 // Action Types
@@ -115,23 +89,6 @@ export function createMemoizedSelector<T extends Record<string, unknown>, D exte
 export type Action<T, P = void> = P extends void
   ? () => Partial<T>
   : (payload: P) => Partial<T>;
-
-/**
- * Create typed action creators
- */
-export function createActions<
-  T extends Record<string, unknown>,
-  A extends Record<string, Action<T, unknown>>
->(
-  store: Store<T>,
-  actions: A
-): {
-  [K in keyof A]: A[K] extends Action<T, infer P>
-    ? P extends void
-      ? () => void
-      : (payload: P) => void
-    : never;
-};
 
 // ============================================================================
 // Reactive State Types

--- a/packages/tooling/package.json
+++ b/packages/tooling/package.json
@@ -15,15 +15,15 @@
       "import": "./dist/testing/index.js"
     },
     "./testing/renderer": {
-      "types": "./types/testing/index.d.ts",
+      "types": "./types/testing/renderer.d.ts",
       "import": "./dist/testing/test-renderer.js"
     },
     "./testing/utils": {
-      "types": "./types/testing/index.d.ts",
+      "types": "./types/testing/utils.d.ts",
       "import": "./dist/testing/test-utils.js"
     },
     "./testing/matchers": {
-      "types": "./types/testing/index.d.ts",
+      "types": "./types/testing/matchers.d.ts",
       "import": "./dist/testing/matchers.js"
     },
     "./lsp": {

--- a/packages/tooling/types/testing/index.d.ts
+++ b/packages/tooling/types/testing/index.d.ts
@@ -88,11 +88,6 @@ export function createTestRenderer(): TestRenderer;
  */
 export function shallowRender(component: CoherentNode): RenderResult;
 
-/**
- * Render a node to HTML string
- */
-export function renderToString(node: CoherentNode): string;
-
 // ============================================================================
 // Custom Matchers for Coherent.js
 // ============================================================================
@@ -253,25 +248,6 @@ export function createSpy<T extends (...args: unknown[]) => unknown>(
 ): Mock<T>;
 
 /**
- * Mock a component
- */
-export function mockComponent<P extends ComponentProps = ComponentProps>(
-  name: string,
-  render?: (props: P) => CoherentNode
-): CoherentComponent<P>;
-
-/**
- * Create test state with reset capability
- */
-export function createTestState<T extends Record<string, unknown>>(
-  initial: T
-): {
-  getState: () => T;
-  setState: (updates: Partial<T>) => void;
-  reset: () => void;
-};
-
-/**
  * Cleanup all mocks and rendered components
  */
 export function cleanup(): void;
@@ -325,14 +301,6 @@ export const userEvent: {
 // ============================================================================
 // Assertion Utilities
 // ============================================================================
-
-/**
- * Assert element structure matches expected
- */
-export function assertElementStructure(
-  element: CoherentElement,
-  expected: Partial<CoherentElement>
-): void;
 
 /**
  * Standard assertions

--- a/packages/tooling/types/testing/index.d.ts
+++ b/packages/tooling/types/testing/index.d.ts
@@ -45,6 +45,38 @@ export interface RenderResult {
   getAllByText(text: string | RegExp): Element[];
 }
 
+/** String-level match returned by TestRendererResult query helpers */
+export interface TestRendererMatch {
+  text: string;
+  html: string;
+  exists: boolean;
+  testId?: string;
+  className?: string;
+}
+
+/**
+ * Result of renderComponent()/renderComponentAsync() — the rendered HTML
+ * plus string-level query helpers over it.
+ */
+export class TestRendererResult {
+  constructor(component: CoherentNode, html: string, container?: unknown);
+  component: CoherentNode;
+  html: string;
+  container: unknown;
+  getByTestId(testId: string): TestRendererMatch;
+  queryByTestId(testId: string): TestRendererMatch | null;
+  getByText(text: string | RegExp): TestRendererMatch;
+  queryByText(text: string | RegExp): TestRendererMatch | null;
+  getByClassName(className: string): TestRendererMatch;
+  queryByClassName(className: string): TestRendererMatch | null;
+  getAllByTagName(tagName: string): TestRendererMatch[];
+  exists(selector: string, type?: 'testId' | 'text' | 'className'): boolean;
+  getHTML(): string;
+  getComponent(): CoherentNode;
+  toSnapshot(): string;
+  debug(): void;
+}
+
 /**
  * Test renderer class
  */

--- a/packages/tooling/types/testing/matchers.d.ts
+++ b/packages/tooling/types/testing/matchers.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Types for the `@coherent.js/tooling/testing/matchers` subpath — the slice of
+ * the shared testing declarations this module actually exports at runtime.
+ */
+export {
+  assertions,
+  customMatchers,
+  extendExpect
+} from './index.js';

--- a/packages/tooling/types/testing/matchers.d.ts
+++ b/packages/tooling/types/testing/matchers.d.ts
@@ -1,7 +1,4 @@
-/**
- * Types for the `@coherent.js/tooling/testing/matchers` subpath — the slice of
- * the shared testing declarations this module actually exports at runtime.
- */
+// The slice of the shared testing declarations this subpath exports at runtime.
 export {
   assertions,
   customMatchers,

--- a/packages/tooling/types/testing/renderer.d.ts
+++ b/packages/tooling/types/testing/renderer.d.ts
@@ -1,0 +1,12 @@
+/**
+ * Types for the `@coherent.js/tooling/testing/renderer` subpath — the slice of
+ * the shared testing declarations this module actually exports at runtime.
+ */
+export {
+  TestRenderer,
+  TestRendererResult,
+  createTestRenderer,
+  renderComponent,
+  renderComponentAsync,
+  shallowRender
+} from './index.js';

--- a/packages/tooling/types/testing/renderer.d.ts
+++ b/packages/tooling/types/testing/renderer.d.ts
@@ -1,7 +1,4 @@
-/**
- * Types for the `@coherent.js/tooling/testing/renderer` subpath — the slice of
- * the shared testing declarations this module actually exports at runtime.
- */
+// The slice of the shared testing declarations this subpath exports at runtime.
 export {
   TestRenderer,
   TestRendererResult,

--- a/packages/tooling/types/testing/utils.d.ts
+++ b/packages/tooling/types/testing/utils.d.ts
@@ -1,0 +1,17 @@
+/**
+ * Types for the `@coherent.js/tooling/testing/utils` subpath — the slice of
+ * the shared testing declarations this module actually exports at runtime.
+ */
+export {
+  act,
+  cleanup,
+  createMock,
+  createSpy,
+  fireEvent,
+  screen,
+  userEvent,
+  waitFor,
+  waitForElement,
+  waitForElementToBeRemoved,
+  within
+} from './index.js';

--- a/packages/tooling/types/testing/utils.d.ts
+++ b/packages/tooling/types/testing/utils.d.ts
@@ -1,7 +1,4 @@
-/**
- * Types for the `@coherent.js/tooling/testing/utils` subpath — the slice of
- * the shared testing declarations this module actually exports at runtime.
- */
+// The slice of the shared testing declarations this subpath exports at runtime.
 export {
   act,
   cleanup,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,11 @@ overrides:
   tmp: ^0.2.6
   '@remix-run/server-runtime': ^2.17.5
   turbo-stream: ^3.0.0
+  undici@<6.27.0: ^6.27.0
+  undici@>=7.0.0 <7.28.0: ^7.28.0
+  astro@<6.4.6: ^6.4.6
+  form-data@>=4.0.0 <4.0.6: ^4.0.6
+  ws@>=8.0.0 <8.21.0: ^8.21.0
 
 importers:
 
@@ -174,8 +179,8 @@ importers:
         specifier: 5.102.1
         version: 5.102.1(esbuild@0.28.1)
       ws:
-        specifier: 8.20.1
-        version: 8.20.1
+        specifier: ^8.21.0
+        version: 8.21.1
 
   packages/client:
     devDependencies:
@@ -227,8 +232,8 @@ importers:
         specifier: '>=2.0.0'
         version: 2.60.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.55.7)(vite@7.3.5(@types/node@26.1.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.23.0)))(svelte@5.55.7)(typescript@5.9.3)(vite@7.3.5(@types/node@26.1.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.23.0))
       astro:
-        specifier: '>=4.0.0'
-        version: 6.3.3(@azure/identity@4.13.1(supports-color@8.1.1))(@types/node@26.1.1)(jiti@2.6.1)(rollup@4.60.4)(supports-color@8.1.1)(terser@5.46.1)(tsx@4.23.0)
+        specifier: ^6.4.6
+        version: 6.4.8(@azure/identity@4.13.1(supports-color@8.1.1))(@types/node@26.1.1)(jiti@2.6.1)(rollup@4.60.4)(supports-color@8.1.1)(terser@5.46.1)(tsx@4.23.0)
       express:
         specifier: '>=4.18.0 < 6.0.0'
         version: 5.2.1(supports-color@8.1.1)
@@ -342,11 +347,11 @@ packages:
   '@astrojs/compiler@4.0.0':
     resolution: {integrity: sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA==}
 
-  '@astrojs/internal-helpers@0.9.1':
-    resolution: {integrity: sha512-1pWuARqYom/TzuU3+0ZugsTrKlUydWKuULmDqSMTuonY+9IRDUEGKX/8PXQ1nBxRq3w85uGtd9q9SXfqEldMIQ==}
+  '@astrojs/internal-helpers@0.10.0':
+    resolution: {integrity: sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw==}
 
-  '@astrojs/markdown-remark@7.1.2':
-    resolution: {integrity: sha512-caXZ4Dc2St2dW8luEg22GlP0gupLdztCTQE4EzZOxW1pqWXz9mbeJEuHUkgDYcKWW8tjIHkydYDhWLVoxJ327Q==}
+  '@astrojs/markdown-remark@7.2.0':
+    resolution: {integrity: sha512-+YxmVQu1Bd+MFfSzjq1rOJvD9+nIOJzz5YIIhdIH01RrxRkKbyKoEgyIqP3yv51MhzMDgd79QaPv+kCVPT8vHw==}
 
   '@astrojs/prism@4.0.2':
     resolution: {integrity: sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA==}
@@ -599,9 +604,6 @@ packages:
 
   '@emnapi/runtime@1.11.2':
     resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
-
-  '@emnapi/runtime@1.9.2':
-    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
 
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
@@ -1968,10 +1970,6 @@ packages:
     resolution: {integrity: sha512-jIXhD0eWQ1JA6ln/5Dltyx22UxWNrw0hZmhy2rlv6m6KgF7kplHx3g0fzi09lNmTJQRR91OlemYp3xFnvDK9og==}
     engines: {node: '>=20.0.0'}
 
-  '@ungap/structured-clone@1.3.0':
-    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
-    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
-
   '@ungap/structured-clone@1.3.2':
     resolution: {integrity: sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==}
 
@@ -2270,8 +2268,8 @@ packages:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
 
-  astro@6.3.3:
-    resolution: {integrity: sha512-wvLIZQYbBZt6U8gyflBW4SLBypaqdwLZUH93rT3oT53cmQ0bTGubvMAGjqBRoheOYzYcTJZtW6czztzbu4kQ5g==}
+  astro@6.4.8:
+    resolution: {integrity: sha512-KK5lX90uU9EeVaTjINyj3sy9/NFXVa59aowaqbWBDDKLXZh4rr7GwIaCFYVetE22MJtsCNFerQXn0vlCLmpP/Q==}
     engines: {node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
 
@@ -2815,9 +2813,6 @@ packages:
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
-  es-module-lexer@2.0.0:
-    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
-
   es-module-lexer@2.3.0:
     resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
 
@@ -3061,8 +3056,8 @@ packages:
     resolution: {integrity: sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==}
     engines: {node: '>=20'}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   forwarded@0.2.0:
@@ -3475,10 +3470,6 @@ packages:
 
   js-yaml@3.14.2:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
-    hasBin: true
-
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
   js-yaml@4.3.0:
@@ -4073,9 +4064,6 @@ packages:
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
-
-  obug@2.1.1:
-    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   obug@2.1.3:
     resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
@@ -4964,10 +4952,6 @@ packages:
     resolution: {integrity: sha512-Ae3OVUqifDw0wBriIBS7yVaW44Dp6eSHQcyq4Igc7eN2TJH/2YsicswaW+J/OuMvhpDPOKEgpAZCjkb4hpoyeA==}
     engines: {node: ^16.14.0 || >= 17.3.0}
 
-  tinyexec@1.1.2:
-    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
-    engines: {node: '>=18'}
-
   tinyexec@1.2.4:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
@@ -5079,16 +5063,12 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@6.25.0:
-    resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
+  undici@6.27.0:
+    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
-  undici@6.26.0:
-    resolution: {integrity: sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==}
-    engines: {node: '>=18.17'}
-
-  undici@7.27.2:
-    resolution: {integrity: sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.1.0:
@@ -5433,18 +5413,6 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.20.1:
-    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
   ws@8.21.1:
     resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
     engines: {node: '>=10.0.0'}
@@ -5541,34 +5509,40 @@ snapshots:
       '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.6)
       '@octokit/request': 10.0.9
       '@octokit/request-error': 7.1.0
-      undici: 6.25.0
+      undici: 6.27.0
 
   '@actions/http-client@3.0.2':
     dependencies:
       tunnel: 0.0.6
-      undici: 6.26.0
+      undici: 6.27.0
 
   '@actions/http-client@4.0.1':
     dependencies:
       tunnel: 0.0.6
-      undici: 6.26.0
+      undici: 6.27.0
 
   '@actions/io@3.0.2': {}
 
   '@astrojs/compiler@4.0.0': {}
 
-  '@astrojs/internal-helpers@0.9.1':
+  '@astrojs/internal-helpers@0.10.0':
     dependencies:
-      picomatch: 4.0.4
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      js-yaml: 4.3.0
+      picomatch: 4.0.5
+      retext-smartypants: 6.2.0
+      shiki: 4.3.1
+      smol-toml: 1.6.1
+      unified: 11.0.5
 
-  '@astrojs/markdown-remark@7.1.2(supports-color@8.1.1)':
+  '@astrojs/markdown-remark@7.2.0(supports-color@8.1.1)':
     dependencies:
-      '@astrojs/internal-helpers': 0.9.1
+      '@astrojs/internal-helpers': 0.10.0
       '@astrojs/prism': 4.0.2
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
       hast-util-to-text: 4.0.2
-      js-yaml: 4.1.1
       mdast-util-definitions: 6.0.0
       rehype-raw: 7.0.0
       rehype-stringify: 10.0.1
@@ -5576,9 +5550,6 @@ snapshots:
       remark-parse: 11.0.0(supports-color@8.1.1)
       remark-rehype: 11.1.2
       remark-smartypants: 3.0.2
-      retext-smartypants: 6.2.0
-      shiki: 4.3.1
-      smol-toml: 1.6.1
       unified: 11.0.5
       unist-util-remove-position: 5.0.0
       unist-util-visit: 5.1.0
@@ -6007,11 +5978,6 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.9.2':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
@@ -6409,7 +6375,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.9.2
+      '@emnapi/runtime': 1.11.2
     optional: true
 
   '@img/sharp-wasm32@0.35.3':
@@ -6626,7 +6592,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
       estree-walker: 2.0.2
-      picomatch: 4.0.4
+      picomatch: 4.0.5
     optionalDependencies:
       rollup: 4.60.4
 
@@ -7037,8 +7003,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@ungap/structured-clone@1.3.0': {}
-
   '@ungap/structured-clone@1.3.2': {}
 
   '@vitest/coverage-v8@4.1.10(vitest@4.1.10)':
@@ -7148,7 +7112,7 @@ snapshots:
       cheerio: 1.2.0
       cockatiel: 3.2.1
       commander: 12.1.0
-      form-data: 4.0.5
+      form-data: 4.0.6
       glob: 13.0.6
       hosted-git-info: 4.1.0
       jsonc-parser: 3.3.1
@@ -7383,11 +7347,11 @@ snapshots:
 
   astral-regex@2.0.0: {}
 
-  astro@6.3.3(@azure/identity@4.13.1(supports-color@8.1.1))(@types/node@26.1.1)(jiti@2.6.1)(rollup@4.60.4)(supports-color@8.1.1)(terser@5.46.1)(tsx@4.23.0):
+  astro@6.4.8(@azure/identity@4.13.1(supports-color@8.1.1))(@types/node@26.1.1)(jiti@2.6.1)(rollup@4.60.4)(supports-color@8.1.1)(terser@5.46.1)(tsx@4.23.0):
     dependencies:
       '@astrojs/compiler': 4.0.0
-      '@astrojs/internal-helpers': 0.9.1
-      '@astrojs/markdown-remark': 7.1.2(supports-color@8.1.1)
+      '@astrojs/internal-helpers': 0.10.0
+      '@astrojs/markdown-remark': 7.2.0(supports-color@8.1.1)
       '@astrojs/telemetry': 3.3.2
       '@capsizecss/unpack': 4.0.0
       '@clack/prompts': 1.4.0
@@ -7402,7 +7366,7 @@ snapshots:
       devalue: 5.8.1
       diff: 8.0.4
       dset: 3.1.4
-      es-module-lexer: 2.0.0
+      es-module-lexer: 2.3.0
       esbuild: 0.27.7
       flattie: 1.1.1
       fontace: 0.4.1
@@ -7410,26 +7374,26 @@ snapshots:
       github-slugger: 2.0.0
       html-escaper: 3.0.3
       http-cache-semantics: 4.2.0
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
       jsonc-parser: 3.3.1
       magic-string: 0.30.21
       magicast: 0.5.3
       mrmime: 2.0.1
       neotraverse: 0.6.18
-      obug: 2.1.1
+      obug: 2.1.3
       p-limit: 7.3.0
       p-queue: 9.3.0
       package-manager-detector: 1.6.0
       piccolore: 0.1.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       rehype: 13.0.2
-      semver: 7.8.0
+      semver: 7.8.5
       shiki: 4.3.1
       smol-toml: 1.6.1
       svgo: 4.0.1
       tinyclip: 0.1.12
-      tinyexec: 1.1.2
-      tinyglobby: 0.2.16
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
       ultrahtml: 1.6.0
       unifont: 0.7.4
       unist-util-visit: 5.1.0
@@ -7664,7 +7628,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.27.2
+      undici: 7.28.0
       whatwg-mimetype: 4.0.0
 
   chokidar@5.0.0:
@@ -7973,8 +7937,6 @@ snapshots:
   es-errors@1.3.0: {}
 
   es-module-lexer@1.7.0: {}
-
-  es-module-lexer@2.0.0: {}
 
   es-module-lexer@2.3.0: {}
 
@@ -8322,7 +8284,7 @@ snapshots:
     dependencies:
       tiny-inflate: 1.0.3
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
@@ -8529,7 +8491,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
       '@types/unist': 3.0.3
-      '@ungap/structured-clone': 1.3.0
+      '@ungap/structured-clone': 1.3.2
       hast-util-from-parse5: 8.0.3
       hast-util-to-parse5: 8.0.1
       html-void-elements: 3.0.0
@@ -8804,10 +8766,6 @@ snapshots:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
-
-  js-yaml@4.1.1:
-    dependencies:
-      argparse: 2.0.1
 
   js-yaml@4.3.0:
     dependencies:
@@ -9593,8 +9551,6 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
-  obug@2.1.1: {}
-
   obug@2.1.3: {}
 
   ofetch@1.5.1:
@@ -10266,7 +10222,7 @@ snapshots:
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
-      semver: 7.7.4
+      semver: 7.8.5
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
       '@img/sharp-darwin-x64': 0.34.5
@@ -10657,8 +10613,6 @@ snapshots:
 
   tinyclip@0.1.12: {}
 
-  tinyexec@1.1.2: {}
-
   tinyexec@1.2.4: {}
 
   tinyglobby@0.2.16:
@@ -10766,11 +10720,9 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@6.25.0: {}
+  undici@6.27.0: {}
 
-  undici@6.26.0: {}
-
-  undici@7.27.2: {}
+  undici@7.28.0: {}
 
   unicorn-magic@0.1.0: {}
 
@@ -11057,8 +11009,6 @@ snapshots:
       strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
-
-  ws@8.20.1: {}
 
   ws@8.21.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -39,3 +39,13 @@ overrides:
   '@remix-run/server-runtime': '^2.17.5'
   # turbo-stream prototype-pollution — only fixed in 3.0.0.
   turbo-stream: '^3.0.0'
+  # undici TLS-validation bypass, WebSocket DoS, cross-origin routing —
+  # fixed in 6.27.0 (6.x line, via @codecov/vite-plugin) and 7.28.0 (7.x).
+  'undici@<6.27.0': '^6.27.0'
+  'undici@>=7.0.0 <7.28.0': '^7.28.0'
+  # astro prerendered-error-page SSRF — fixed in 6.4.6.
+  'astro@<6.4.6': '^6.4.6'
+  # form-data CRLF injection — fixed in 4.0.6 (via @vscode/vsce).
+  'form-data@>=4.0.0 <4.0.6': '^4.0.6'
+  # ws memory-exhaustion DoS from tiny fragments — fixed in 8.21.0.
+  'ws@>=8.0.0 <8.21.0': '^8.21.0'

--- a/scripts/check-api-surface.mjs
+++ b/scripts/check-api-surface.mjs
@@ -119,13 +119,19 @@ async function snapshotPackage(pkg) {
 
 /**
  * Extract value-export names declared in a .d.ts file.
- * Only definitive value declarations (function/const/class/let/var) are
- * returned — brace re-exports may cover interfaces and are intentionally
- * excluded so type-only names can't be misread as runtime values.
+ * Direct declarations (function/const/class/let/var) count as values.
+ * `export { a, b } from './x'` counts a braced name only when the source
+ * file declares it as a value — interfaces and other type-only names in a
+ * brace list can't be misread as runtime values.
  */
+const dtsValueCache = new Map();
+
 function parseDtsValueExports(dtsPath) {
-  const source = readFileSync(dtsPath, 'utf8');
+  if (dtsValueCache.has(dtsPath)) return dtsValueCache.get(dtsPath);
   const names = new Set();
+  dtsValueCache.set(dtsPath, names); // registered before recursion to break cycles
+  const source = readFileSync(dtsPath, 'utf8');
+
   const patterns = [
     /^export\s+(?:declare\s+)?(?:async\s+)?function\s+([A-Za-z_$][\w$]*)/gm,
     /^export\s+(?:declare\s+)?(?:const|let|var)\s+([A-Za-z_$][\w$]*)/gm,
@@ -135,6 +141,26 @@ function parseDtsValueExports(dtsPath) {
     let m;
     while ((m = re.exec(source)) !== null) names.add(m[1]);
   }
+
+  const reexportRe = /^export\s*\{([^}]+)\}\s*from\s*['"]([^'"]+)['"]/gm;
+  let m;
+  while ((m = reexportRe.exec(source)) !== null) {
+    const specifier = m[2];
+    if (!specifier.startsWith('.')) continue;
+    let targetPath = resolve(dirname(dtsPath), specifier.replace(/\.js$/i, '.d.ts'));
+    if (!existsSync(targetPath)) {
+      targetPath = resolve(dirname(dtsPath), specifier, 'index.d.ts');
+      if (!existsSync(targetPath)) continue;
+    }
+    const sourceValues = parseDtsValueExports(targetPath);
+    for (const entry of m[1].split(',')) {
+      const spec = entry.trim();
+      if (!spec || spec.startsWith('type ')) continue;
+      const [original, alias] = spec.split(/\s+as\s+/).map((s) => s.trim());
+      if (sourceValues.has(original)) names.add(alias || original);
+    }
+  }
+
   return names;
 }
 
@@ -164,7 +190,7 @@ function checkTypesParity(pkg, sections) {
     const runtime = new Set(section.exports);
     for (const name of declared) {
       if (!runtime.has(name)) {
-        phantoms.push(`${section.subpath}: \`${name}\` declared in ${typesPath.replace(REPO_ROOT + '/', '')} but not exported at runtime`);
+        phantoms.push(`${section.subpath}: \`${name}\` declared in ${typesPath.replace(`${REPO_ROOT}/`, '')} but not exported at runtime`);
       }
     }
   }

--- a/scripts/check-api-surface.mjs
+++ b/scripts/check-api-surface.mjs
@@ -113,7 +113,74 @@ async function snapshotPackage(pkg) {
   const missingTargets = sections
     .filter(({ note }) => note && note.startsWith('target file missing'))
     .map(({ subpath, note }) => `${subpath}: ${note}`);
-  return { name: pkg.name, dir: pkg.dir, missingTargets, content: formatSnapshot(`@coherent.js/${pkg.name}`, sections) };
+  const phantomTypes = checkTypesParity(pkg, sections);
+  return { name: pkg.name, dir: pkg.dir, missingTargets, phantomTypes, content: formatSnapshot(`@coherent.js/${pkg.name}`, sections) };
+}
+
+/**
+ * Extract value-export names declared in a .d.ts file.
+ * Only definitive value declarations (function/const/class/let/var) are
+ * returned — brace re-exports may cover interfaces and are intentionally
+ * excluded so type-only names can't be misread as runtime values.
+ */
+function parseDtsValueExports(dtsPath) {
+  const source = readFileSync(dtsPath, 'utf8');
+  const names = new Set();
+  const patterns = [
+    /^export\s+(?:declare\s+)?(?:async\s+)?function\s+([A-Za-z_$][\w$]*)/gm,
+    /^export\s+(?:declare\s+)?(?:const|let|var)\s+([A-Za-z_$][\w$]*)/gm,
+    /^export\s+(?:declare\s+)?(?:abstract\s+)?class\s+([A-Za-z_$][\w$]*)/gm,
+  ];
+  for (const re of patterns) {
+    let m;
+    while ((m = re.exec(source)) !== null) names.add(m[1]);
+  }
+  return names;
+}
+
+function resolveTypesPath(pkg, subpath, exportValue) {
+  if (exportValue && typeof exportValue === 'object' && typeof exportValue.types === 'string') {
+    return resolve(pkg.dir, exportValue.types);
+  }
+  if (subpath === '.' && typeof pkg.pkgJson.types === 'string') {
+    return resolve(pkg.dir, pkg.pkgJson.types);
+  }
+  return null;
+}
+
+/**
+ * Types-parity gate: every value export declared in a subpath's .d.ts must
+ * exist at runtime. Phantom declarations let broken consumer code typecheck
+ * and then crash (`createI18n is not a function`), so they are a hard failure.
+ */
+function checkTypesParity(pkg, sections) {
+  const phantoms = [];
+  for (const section of sections) {
+    if (!section.exports) continue; // no runtime snapshot to compare against
+    const exportValue = pkg.pkgJson.exports[section.subpath];
+    const typesPath = resolveTypesPath(pkg, section.subpath, exportValue);
+    if (!typesPath || !existsSync(typesPath)) continue;
+    const declared = parseDtsValueExports(typesPath);
+    const runtime = new Set(section.exports);
+    for (const name of declared) {
+      if (!runtime.has(name)) {
+        phantoms.push(`${section.subpath}: \`${name}\` declared in ${typesPath.replace(REPO_ROOT + '/', '')} but not exported at runtime`);
+      }
+    }
+  }
+  return phantoms;
+}
+
+function reportPhantomTypes(results) {
+  const broken = results.filter(({ phantomTypes }) => phantomTypes && phantomTypes.length > 0);
+  if (broken.length === 0) return false;
+  console.error('❌ Phantom type declarations (typed but missing at runtime):');
+  for (const { name, phantomTypes } of broken) {
+    for (const entry of phantomTypes) {
+      console.error(`  - ${name}: ${entry}`);
+    }
+  }
+  return true;
 }
 
 // A subpath whose target file doesn't exist is always a hard failure — it
@@ -142,7 +209,8 @@ async function runWrite() {
     writeFileSync(target, result.content, 'utf8');
     console.log(`  ✓ ${result.name}: wrote ${target.replace(REPO_ROOT + '/', '')}`);
   }
-  if (reportMissingTargets(results)) {
+  const failed = reportMissingTargets(results) | reportPhantomTypes(results);
+  if (failed) {
     process.exitCode = 1;
     return;
   }
@@ -169,8 +237,9 @@ async function runCheck() {
     }
   }
   const hasMissingTargets = reportMissingTargets(results);
+  const hasPhantomTypes = reportPhantomTypes(results);
   if (failures.length === 0) {
-    if (hasMissingTargets) {
+    if (hasMissingTargets || hasPhantomTypes) {
       process.exitCode = 1;
       return;
     }

--- a/scripts/scaffold-boot-e2e.mjs
+++ b/scripts/scaffold-boot-e2e.mjs
@@ -12,13 +12,11 @@ import { join, resolve, dirname } from 'node:path';
 import { tmpdir } from 'node:os';
 import { spawn, spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { createRequire } from 'node:module';
 import process from 'node:process';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..');
 const PACKAGES_DIR = join(REPO_ROOT, 'packages');
-const require = createRequire(join(REPO_ROOT, 'package.json'));
 
 const { scaffoldProject } = await import(
   new URL('../packages/cli/src/generators/project-scaffold.js', import.meta.url)
@@ -78,7 +76,8 @@ function linkWorkspaceDeps(projectPath, hasFastify) {
     // The linked integrations package resolves the monorepo's fastify copy;
     // pin the project to the same version so TS sees one set of fastify types
     // (real installs share a single copy via peer resolution).
-    const fastifyVersion = require('fastify/package.json').version;
+    const fastifyManifest = fileURLToPath(import.meta.resolve('fastify/package.json'));
+    const fastifyVersion = JSON.parse(readFileSync(fastifyManifest, 'utf8')).version;
     pkg.pnpm = { overrides: { fastify: fastifyVersion } };
   }
   writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
@@ -114,9 +113,12 @@ async function bootAndProbe(projectPath, permutation) {
   let output = '';
   child.stdout.on('data', (d) => { output += d; });
   child.stderr.on('data', (d) => { output += d; });
+  const spawnFailure = new Promise((_, reject) => {
+    child.on('error', (error) => reject(new Error(`server process failed to spawn: ${error.message}`)));
+  });
 
   try {
-    const res = await waitForServer(port);
+    const res = await Promise.race([waitForServer(port), spawnFailure]);
     const html = await res.text();
     if (!html.includes('<h1>')) {
       throw new Error(`homepage did not render a heading:\n${html.slice(0, 300)}`);

--- a/scripts/scaffold-boot-e2e.mjs
+++ b/scripts/scaffold-boot-e2e.mjs
@@ -1,0 +1,217 @@
+#!/usr/bin/env node
+/**
+ * Scaffold Boot E2E
+ *
+ * The gap that let rc.1 and rc.2 ship broken scaffolds: nothing installed,
+ * typechecked, tested, and *booted* the projects `coherent create` produces.
+ * This harness does exactly that for representative permutations, against the
+ * workspace packages (linked via `link:` deps), so scaffold or integration
+ * regressions surface before publish.
+ *
+ * Requires built packages (`pnpm run build:packages`) — run locally with
+ * `pnpm run e2e:scaffold`, or via .github/workflows/scaffold-e2e.yml.
+ *
+ * @module scripts/scaffold-boot-e2e
+ */
+
+import { mkdtempSync, readFileSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawn, spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+import process from 'node:process';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+const PACKAGES_DIR = join(REPO_ROOT, 'packages');
+const require = createRequire(join(REPO_ROOT, 'package.json'));
+
+const { scaffoldProject } = await import(
+  new URL('../packages/cli/src/generators/project-scaffold.js', import.meta.url)
+);
+
+const PERMUTATIONS = [
+  {
+    name: 'js-built-in-basic',
+    options: { language: 'javascript', runtime: 'built-in', packages: [] },
+    port: 4311
+  },
+  {
+    name: 'js-koa-api',
+    options: { language: 'javascript', runtime: 'koa', packages: ['api'] },
+    port: 4312
+  },
+  {
+    name: 'ts-express-api',
+    options: { language: 'typescript', runtime: 'express', packages: ['api'] },
+    port: 4313
+  },
+  {
+    name: 'ts-fastify-full',
+    options: {
+      language: 'typescript',
+      runtime: 'fastify',
+      packages: ['api', 'i18n', 'forms', 'seo', 'testing']
+    },
+    port: 4314
+  }
+  // TODO(v1.1): fullstack + database + auth permutations once the tracked
+  // auth-scaffold gaps (password hashing, built-in setupAuthRoutes) close.
+];
+
+function run(cmd, args, opts = {}) {
+  const result = spawnSync(cmd, args, { encoding: 'utf8', ...opts });
+  if (result.status !== 0) {
+    throw new Error(
+      `${cmd} ${args.join(' ')} failed (exit ${result.status})\n${result.stdout}\n${result.stderr}`
+    );
+  }
+  return result;
+}
+
+function linkWorkspaceDeps(projectPath, hasFastify) {
+  const pkgPath = join(projectPath, 'package.json');
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+  for (const deps of [pkg.dependencies, pkg.devDependencies]) {
+    if (!deps) continue;
+    for (const name of Object.keys(deps)) {
+      if (name.startsWith('@coherent.js/')) {
+        deps[name] = `link:${join(PACKAGES_DIR, name.replace('@coherent.js/', ''))}`;
+      }
+    }
+  }
+  if (hasFastify) {
+    // The linked integrations package resolves the monorepo's fastify copy;
+    // pin the project to the same version so TS sees one set of fastify types
+    // (real installs share a single copy via peer resolution).
+    const fastifyVersion = require('fastify/package.json').version;
+    pkg.pnpm = { overrides: { fastify: fastifyVersion } };
+  }
+  writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));
+}
+
+async function waitForServer(port, timeoutMs = 30_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/`);
+      if (res.ok) return res;
+    } catch {
+      // not up yet
+    }
+    await new Promise((r) => setTimeout(r, 300));
+  }
+  throw new Error(`server did not answer on port ${port} within ${timeoutMs}ms`);
+}
+
+async function bootAndProbe(projectPath, permutation) {
+  const { port } = permutation;
+  const isTypeScript = permutation.options.language === 'typescript';
+  const entry = isTypeScript
+    ? ['./node_modules/.bin/tsx', ['src/index.ts']]
+    : [process.execPath, ['src/index.js']];
+
+  const child = spawn(entry[0], entry[1], {
+    cwd: projectPath,
+    env: { ...process.env, PORT: String(port), NODE_ENV: 'development' },
+    detached: true,
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  let output = '';
+  child.stdout.on('data', (d) => { output += d; });
+  child.stderr.on('data', (d) => { output += d; });
+
+  try {
+    const res = await waitForServer(port);
+    const html = await res.text();
+    if (!html.includes('<h1>')) {
+      throw new Error(`homepage did not render a heading:\n${html.slice(0, 300)}`);
+    }
+
+    if (permutation.options.packages.includes('api')) {
+      const getRes = await fetch(`http://127.0.0.1:${port}/api/users/7`);
+      const getBody = await getRes.json();
+      if (getBody.id !== 7) {
+        throw new Error(`GET /api/users/7 returned ${JSON.stringify(getBody)}`);
+      }
+      const postRes = await fetch(`http://127.0.0.1:${port}/api/users`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Ada', email: 'ada@example.com' })
+      });
+      const postBody = await postRes.json();
+      if (postBody.name !== 'Ada') {
+        throw new Error(`POST /api/users returned ${JSON.stringify(postBody)}`);
+      }
+    }
+  } catch (error) {
+    error.message += `\n--- server output ---\n${output.slice(-2000)}`;
+    throw error;
+  } finally {
+    try { process.kill(-child.pid, 'SIGTERM'); } catch { /* already gone */ }
+  }
+}
+
+async function testPermutation(permutation) {
+  const started = Date.now();
+  const projectPath = mkdtempSync(join(tmpdir(), `coherent-boot-${permutation.name}-`));
+  console.log(`\n▶ ${permutation.name}`);
+
+  try {
+    await scaffoldProject(projectPath, {
+      name: permutation.name,
+      template: 'basic',
+      ...permutation.options,
+      packageManager: 'pnpm',
+      skipInstall: true,
+      skipGit: true
+    });
+
+    linkWorkspaceDeps(projectPath, permutation.options.runtime === 'fastify');
+
+    run('pnpm', ['install', '--silent'], { cwd: projectPath });
+    console.log('  install ✓');
+
+    if (permutation.options.language === 'typescript') {
+      run('pnpm', ['typecheck'], { cwd: projectPath });
+      console.log('  typecheck ✓');
+    }
+
+    run('pnpm', ['test'], { cwd: projectPath });
+    console.log('  tests ✓');
+
+    await bootAndProbe(projectPath, permutation);
+    console.log(`  boot + HTTP probes ✓ (${((Date.now() - started) / 1000).toFixed(1)}s)`);
+    return true;
+  } catch (error) {
+    console.error(`  ✗ ${permutation.name} FAILED:\n${error.message}`);
+    return false;
+  } finally {
+    rmSync(projectPath, { recursive: true, force: true });
+  }
+}
+
+async function main() {
+  if (!existsSync(join(PACKAGES_DIR, 'core', 'dist', 'index.js'))) {
+    console.error('Built packages required — run `pnpm run build:packages` first.');
+    process.exit(2);
+  }
+
+  console.log(`Scaffold boot E2E — ${PERMUTATIONS.length} permutations`);
+  let failed = 0;
+  for (const permutation of PERMUTATIONS) {
+    if (!(await testPermutation(permutation))) failed++;
+  }
+
+  if (failed > 0) {
+    console.error(`\n❌ ${failed}/${PERMUTATIONS.length} permutations failed`);
+    process.exit(1);
+  }
+  console.log(`\n✅ All ${PERMUTATIONS.length} scaffold permutations install, typecheck, test, and boot.`);
+}
+
+main().catch((error) => {
+  console.error('Unexpected error:', error);
+  process.exit(3);
+});

--- a/scripts/scaffold-boot-e2e.mjs
+++ b/scripts/scaffold-boot-e2e.mjs
@@ -1,15 +1,8 @@
 #!/usr/bin/env node
 /**
- * Scaffold Boot E2E
- *
- * The gap that let rc.1 and rc.2 ship broken scaffolds: nothing installed,
- * typechecked, tested, and *booted* the projects `coherent create` produces.
- * This harness does exactly that for representative permutations, against the
- * workspace packages (linked via `link:` deps), so scaffold or integration
- * regressions surface before publish.
- *
- * Requires built packages (`pnpm run build:packages`) — run locally with
- * `pnpm run e2e:scaffold`, or via .github/workflows/scaffold-e2e.yml.
+ * Installs, typechecks, tests, and boots representative `coherent create`
+ * permutations against the workspace packages (linked via `link:` deps).
+ * Requires built packages (`pnpm run build:packages`).
  *
  * @module scripts/scaffold-boot-e2e
  */
@@ -98,7 +91,7 @@ async function waitForServer(port, timeoutMs = 30_000) {
       const res = await fetch(`http://127.0.0.1:${port}/`);
       if (res.ok) return res;
     } catch {
-      // not up yet
+      // server not accepting connections yet
     }
     await new Promise((r) => setTimeout(r, 300));
   }


### PR DESCRIPTION
Three guardrails that would have prevented nearly every bug found in the rc.3 quality sweep:

## 1. `fix(core)`: void elements render without closing tags
`renderObjectElement` — the path every `{ meta: {...} }` component takes — unconditionally appended a closing tag, emitting invalid HTML like `<meta></meta>` on every page including the website's own head. Now short-circuits to the bare opening tag per spec, with regression tests.

## 2. `fix(types)`: types-parity gate + 123-phantom cleanup
`check-api-surface` now hard-fails when a `.d.ts` declares a value (function/const/class) that doesn't exist at runtime — the exact mechanism behind `createI18n is not a function` (the scaffolds and docs hallucinated their fabricated APIs straight from the types). First run found **123 phantoms**: 69 declarations deleted across 8 packages, tooling's four testing subpaths got per-slice declaration files instead of one shared union, and `ObjectRouter` gained the methods it actually has (with `toExpressRouter` typed via a structural generic — no `any`).

## 3. `test(cli)`: scaffold boot E2E
Closes the tracked rc.2 gap that let rc.1 and rc.2 ship scaffolds that couldn't boot. Scaffolds four representative permutations against the workspace packages, then runs each generated project's install, typecheck, and test scripts, boots the server, and probes `/` and the `/api` routes over HTTP. Runs nightly + on PRs touching cli/integrations/core/api. Its first run immediately caught two real bugs in the never-before-tested ts/express permutation (both fixed here).

All gates verified locally: lint, typecheck, 94 test files, api-surface (including the new parity check), bundle-size (core +0.2%), Playwright e2e, and the scaffold boot harness itself (4/4 permutations green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added method-specific API route helpers and server integration options.
  - Added form-building support and expanded testing utilities, matchers, and renderer entry points.
  - Added automated scaffold verification for representative project configurations.

- **Bug Fixes**
  - Void HTML elements now render correctly without closing tags or unintended child content.

- **TypeScript**
  - Improved generated Express error-handler typings for TypeScript projects.
  - Removed deprecated or unsupported public type declarations across several packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->