### PR TITLE
fix(cli): auth scaffolds hash and verify passwords, typecheck under strict TS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Auth scaffolds actually authenticate.** Generated register handlers silently discarded the password (`// you should hash the password!`) and login handlers issued a valid JWT for **any** password on a known email — an authentication bypass in every generated project. Registration now hashes with scrypt (Node's built-in KDF — zero new dependencies; stored as `scrypt:<salt>:<hash>`) and login verifies with `timingSafeEqual`, across all four runtimes (express, fastify, koa, built-in), both JWT and session flavors. The database models gained the matching `password_hash` column/insert (it existed but was never written for postgres/mysql, and was missing entirely for sqlite).
+- **TypeScript auth/database scaffolds typecheck.** TS projects with auth or a database produced code that failed `tsc --noEmit` outright: implicit-`any` parameters throughout the auth middleware/routes and database models, an untyped `jwt.sign` expiresIn, a non-portable inferred express `Router` type, pino-incompatible `fastify.log.error` calls, and strict-mode errors in the built-in server's route matcher. All templates are now emitted with proper annotations when the project is TypeScript.
+- **Auth-only scaffolds boot.** `hasApi` conflated "api package selected" with "has auth", so a project with auth but without the api package imported a nonexistent `./api/routes.js` and crashed on startup.
+- **Session auth is only offered for express** — the generator only has session routes for express; other runtimes previously produced an empty routes file.
+
+### Added
+
+- Scaffold boot E2E gained two auth permutations (`js-built-in-auth-sqlite`, `ts-express-auth-sqlite`) that register, log in, assert a **wrong password is rejected with 401**, and fetch `/me` with the issued token — closing the tracked rc.2 gap.
+
 ## [1.0.0-rc.5] - 2026-07-19
 
 Dependency-truth release: what the published packages declare now matches what they need at runtime, and the audit is clean.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **TypeScript auth/database scaffolds typecheck.** TS projects with auth or a database produced code that failed `tsc --noEmit` outright: implicit-`any` parameters throughout the auth middleware/routes and database models, an untyped `jwt.sign` expiresIn, a non-portable inferred express `Router` type, pino-incompatible `fastify.log.error` calls, and strict-mode errors in the built-in server's route matcher. All templates are now emitted with proper annotations when the project is TypeScript.
 - **Auth-only scaffolds boot.** `hasApi` conflated "api package selected" with "has auth", so a project with auth but without the api package imported a nonexistent `./api/routes.js` and crashed on startup.
 - **Session auth is only offered for express** — the generator only has session routes for express; other runtimes previously produced an empty routes file.
+- **Auth scaffolding requires a SQL database.** Auth could previously be selected without any database (the generated routes then imported a nonexistent `../db/models/User.js` and crashed on boot) or with MongoDB, whose generated model calls an API the database manager doesn't expose and whose `_id` documents don't fit the numeric-token flow. The CLI now gates the prompt and validates the flags accordingly; MongoDB auth is tracked as a follow-up.
+- **MySQL scaffold model reads the adapter's real result shape.** The adapter normalizes results to `{ rows, insertId, … }`, so the generated model's `result[0]` was always `undefined` — every MySQL model method silently returned nothing. Reads now use `result.rows[0]` and writes re-fetch by id, matching the sqlite template.
+- **SQL model `update` is typed as it behaves** — it sets both columns unconditionally, so its TS signature takes `Pick<UserData, 'email' | 'name'>` instead of the misleading `Partial<UserData>`; Mongo ids are typed `string`, not `number`.
 
 ### Added
 

--- a/packages/cli/src/commands/create.js
+++ b/packages/cli/src/commands/create.js
@@ -207,17 +207,20 @@ export const createCommand = new Command('create')
         packages = template === 'fullstack' ? ['api'] : [];
       }
 
-      // Auth scaffolding
+      // Auth scaffolding (session routes are only generated for express)
       if (!options.skipPrompts && (packages.includes('api') || database)) {
+        const authChoices = [
+          { title: '🔑 JWT Authentication', value: 'jwt', description: 'Token-based auth with jsonwebtoken' },
+          ...(runtime === 'express'
+            ? [{ title: '🍪 Session Authentication', value: 'session', description: 'Cookie-based session auth' }]
+            : []),
+          { title: '❌ None', value: 'none', description: 'Skip authentication setup' }
+        ];
         const authResponse = await prompts({
           type: 'select',
           name: 'auth',
           message: 'Would you like to include authentication scaffolding?',
-          choices: [
-            { title: '🔑 JWT Authentication', value: 'jwt', description: 'Token-based auth with jsonwebtoken' },
-            { title: '🍪 Session Authentication', value: 'session', description: 'Cookie-based session auth' },
-            { title: '❌ None', value: 'none', description: 'Skip authentication setup' }
-          ],
+          choices: authChoices,
           initial: 0
         });
 
@@ -238,6 +241,11 @@ export const createCommand = new Command('create')
       });
 
       packages = pkgResponse.packages || [];
+    }
+
+    if (auth === 'session' && runtime !== 'express') {
+      console.error(picocolors.red('✖ Session auth scaffolding is only available for the express runtime. Use --auth jwt, or --runtime express.'));
+      process.exit(1);
     }
 
     // Package manager selection

--- a/packages/cli/src/commands/create.js
+++ b/packages/cli/src/commands/create.js
@@ -207,8 +207,9 @@ export const createCommand = new Command('create')
         packages = template === 'fullstack' ? ['api'] : [];
       }
 
-      // Auth scaffolding (session routes are only generated for express)
-      if (!options.skipPrompts && (packages.includes('api') || database)) {
+      // Auth scaffolding needs the generated UserModel, so it requires a SQL
+      // database; session routes are only generated for express.
+      if (!options.skipPrompts && database && database !== 'mongodb') {
         const authChoices = [
           { title: '🔑 JWT Authentication', value: 'jwt', description: 'Token-based auth with jsonwebtoken' },
           ...(runtime === 'express'
@@ -241,6 +242,16 @@ export const createCommand = new Command('create')
       });
 
       packages = pkgResponse.packages || [];
+    }
+
+    if (auth && !database) {
+      console.error(picocolors.red('✖ Auth scaffolding requires a database (it generates login against the User model). Add --database sqlite|postgres|mysql.'));
+      process.exit(1);
+    }
+
+    if (auth && database === 'mongodb') {
+      console.error(picocolors.red('✖ Auth scaffolding requires a SQL database (sqlite, postgres, mysql) — MongoDB auth is not supported yet.'));
+      process.exit(1);
     }
 
     if (auth === 'session' && runtime !== 'express') {

--- a/packages/cli/src/generators/auth-scaffold.js
+++ b/packages/cli/src/generators/auth-scaffold.js
@@ -4,47 +4,96 @@
  */
 
 /**
+ * Password-hashing helpers emitted into every auth middleware/plugin file.
+ * scrypt is Node's built-in KDF, so generated projects get real hashing
+ * with zero extra dependencies. Stored format: "scrypt:<salt>:<hash>" (hex).
+ */
+function passwordHelpers(ts) {
+  return `
+const scryptAsync = promisify(scrypt)${ts ? ' as (password: string, salt: string, keylen: number) => Promise<Buffer>' : ''};
+
+export async function hashPassword(password${ts ? ': string' : ''})${ts ? ': Promise<string>' : ''} {
+  const salt = randomBytes(16).toString('hex');
+  const derived = await scryptAsync(password, salt, 64);
+  return \`scrypt:\${salt}:\${derived.toString('hex')}\`;
+}
+
+export async function verifyPassword(password${ts ? ': string' : ''}, storedHash${ts ? ': unknown' : ''})${ts ? ': Promise<boolean>' : ''} {
+  const [scheme, salt, hash] = String(storedHash ?? '').split(':');
+  if (scheme !== 'scrypt' || !salt || !hash) return false;
+  const derived = await scryptAsync(password, salt, 64);
+  const expected = Buffer.from(hash, 'hex');
+  // timingSafeEqual, so the comparison doesn't leak how much of the hash matched
+  return expected.length === derived.length && timingSafeEqual(derived, expected);
+}
+`;
+}
+
+const CRYPTO_IMPORTS = `import { randomBytes, scrypt, timingSafeEqual } from 'node:crypto';
+import { promisify } from 'node:util';`;
+
+/**
  * Generate JWT authentication middleware
  */
-export function generateJWTAuth(runtime) {
-  const middlewares = {
-    express: `
-import jwt from 'jsonwebtoken';
-
-const JWT_SECRET = process.env.JWT_SECRET || 'your-secret-key-change-this';
-const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || '7d';
-
-export function generateToken(payload) {
+export function generateJWTAuth(runtime, language = 'javascript') {
+  const ts = language === 'typescript';
+  const helpers = passwordHelpers(ts);
+  const jwtConstants = `const JWT_SECRET = process.env.JWT_SECRET || 'your-secret-key-change-this';
+const JWT_EXPIRES_IN = (process.env.JWT_EXPIRES_IN || '7d')${ts ? " as jwt.SignOptions['expiresIn']" : ''};`;
+  const tokenPayload = ts
+    ? `
+export interface TokenPayload {
+  id: number;
+  email: string;
+}
+`
+    : '';
+  const tokenFns = `
+export function generateToken(payload${ts ? ': TokenPayload' : ''})${ts ? ': string' : ''} {
   return jwt.sign(payload, JWT_SECRET, { expiresIn: JWT_EXPIRES_IN });
 }
 
-export function verifyToken(token) {
+export function verifyToken(token${ts ? ': string' : ''})${ts ? ': TokenPayload | null' : ''} {
   try {
-    return jwt.verify(token, JWT_SECRET);
+    return jwt.verify(token, JWT_SECRET)${ts ? ' as TokenPayload' : ''};
   } catch (error) {
     return null;
   }
 }
+`;
 
-export function authMiddleware(req, res, next) {
+  const middlewares = {
+    express: `
+import jwt from 'jsonwebtoken';
+${CRYPTO_IMPORTS}
+${ts ? "import type { Request, Response, NextFunction } from 'express';\n" : ''}
+${jwtConstants}
+${tokenPayload}${ts ? `
+export interface AuthenticatedRequest extends Request {
+  user?: TokenPayload;
+}
+` : ''}${helpers}${tokenFns}
+export function authMiddleware(req${ts ? ': AuthenticatedRequest' : ''}, res${ts ? ': Response' : ''}, next${ts ? ': NextFunction' : ''})${ts ? ': void' : ''} {
   const authHeader = req.headers.authorization;
 
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
-    return res.status(401).json({ error: 'No token provided' });
+    res.status(401).json({ error: 'No token provided' });
+    return;
   }
 
   const token = authHeader.substring(7);
   const decoded = verifyToken(token);
 
   if (!decoded) {
-    return res.status(401).json({ error: 'Invalid or expired token' });
+    res.status(401).json({ error: 'Invalid or expired token' });
+    return;
   }
 
   req.user = decoded;
   next();
 }
 
-export function optionalAuth(req, res, next) {
+export function optionalAuth(req${ts ? ': AuthenticatedRequest' : ''}, _res${ts ? ': Response' : ''}, next${ts ? ': NextFunction' : ''})${ts ? ': void' : ''} {
   const authHeader = req.headers.authorization;
 
   if (authHeader && authHeader.startsWith('Bearer ')) {
@@ -60,24 +109,22 @@ export function optionalAuth(req, res, next) {
 `,
     fastify: `
 import jwt from 'jsonwebtoken';
-
-const JWT_SECRET = process.env.JWT_SECRET || 'your-secret-key-change-this';
-const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || '7d';
-
-export function generateToken(payload) {
-  return jwt.sign(payload, JWT_SECRET, { expiresIn: JWT_EXPIRES_IN });
-}
-
-export function verifyToken(token) {
-  try {
-    return jwt.verify(token, JWT_SECRET);
-  } catch (error) {
-    return null;
+${CRYPTO_IMPORTS}
+${ts ? "import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';\n" : ''}
+${jwtConstants}
+${tokenPayload}${ts ? `
+declare module 'fastify' {
+  interface FastifyRequest {
+    user?: TokenPayload;
+  }
+  interface FastifyInstance {
+    authenticate: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
+    optionalAuth: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
   }
 }
-
-export async function authPlugin(fastify, options) {
-  fastify.decorate('authenticate', async function(request, reply) {
+` : ''}${helpers}${tokenFns}
+export async function authPlugin(fastify${ts ? ': FastifyInstance' : ''}, _options${ts ? ': unknown' : ''})${ts ? ': Promise<void>' : ''} {
+  fastify.decorate('authenticate', async function(request${ts ? ': FastifyRequest' : ''}, reply${ts ? ': FastifyReply' : ''}) {
     const authHeader = request.headers.authorization;
 
     if (!authHeader || !authHeader.startsWith('Bearer ')) {
@@ -96,7 +143,7 @@ export async function authPlugin(fastify, options) {
     request.user = decoded;
   });
 
-  fastify.decorate('optionalAuth', async function(request, reply) {
+  fastify.decorate('optionalAuth', async function(request${ts ? ': FastifyRequest' : ''}, _reply${ts ? ': FastifyReply' : ''}) {
     const authHeader = request.headers.authorization;
 
     if (authHeader && authHeader.startsWith('Bearer ')) {
@@ -111,23 +158,11 @@ export async function authPlugin(fastify, options) {
 `,
     koa: `
 import jwt from 'jsonwebtoken';
-
-const JWT_SECRET = process.env.JWT_SECRET || 'your-secret-key-change-this';
-const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || '7d';
-
-export function generateToken(payload) {
-  return jwt.sign(payload, JWT_SECRET, { expiresIn: JWT_EXPIRES_IN });
-}
-
-export function verifyToken(token) {
-  try {
-    return jwt.verify(token, JWT_SECRET);
-  } catch (error) {
-    return null;
-  }
-}
-
-export async function authMiddleware(ctx, next) {
+${CRYPTO_IMPORTS}
+${ts ? "import type { Context, Next } from 'koa';\n" : ''}
+${jwtConstants}
+${tokenPayload}${helpers}${tokenFns}
+export async function authMiddleware(ctx${ts ? ': Context' : ''}, next${ts ? ': Next' : ''})${ts ? ': Promise<void>' : ''} {
   const authHeader = ctx.headers.authorization;
 
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
@@ -149,7 +184,7 @@ export async function authMiddleware(ctx, next) {
   await next();
 }
 
-export async function optionalAuth(ctx, next) {
+export async function optionalAuth(ctx${ts ? ': Context' : ''}, next${ts ? ': Next' : ''})${ts ? ': Promise<void>' : ''} {
   const authHeader = ctx.headers.authorization;
 
   if (authHeader && authHeader.startsWith('Bearer ')) {
@@ -165,23 +200,11 @@ export async function optionalAuth(ctx, next) {
 `,
     'built-in': `
 import jwt from 'jsonwebtoken';
-
-const JWT_SECRET = process.env.JWT_SECRET || 'your-secret-key-change-this';
-const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || '7d';
-
-export function generateToken(payload) {
-  return jwt.sign(payload, JWT_SECRET, { expiresIn: JWT_EXPIRES_IN });
-}
-
-export function verifyToken(token) {
-  try {
-    return jwt.verify(token, JWT_SECRET);
-  } catch (error) {
-    return null;
-  }
-}
-
-export function authenticateRequest(req) {
+${CRYPTO_IMPORTS}
+${ts ? "import type { IncomingMessage } from 'node:http';\n" : ''}
+${jwtConstants}
+${tokenPayload}${helpers}${tokenFns}
+export function authenticateRequest(req${ts ? ': IncomingMessage' : ''})${ts ? ': TokenPayload | null' : ''} {
   const authHeader = req.headers.authorization;
 
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
@@ -200,11 +223,21 @@ export function authenticateRequest(req) {
 /**
  * Generate session-based authentication
  */
-export function generateSessionAuth(runtime) {
+export function generateSessionAuth(runtime, language = 'javascript') {
+  const ts = language === 'typescript';
+  const helpers = passwordHelpers(ts);
+
   const middlewares = {
     express: `
 import session from 'express-session';
-
+${CRYPTO_IMPORTS}
+${ts ? "import type { Express, Request, Response, NextFunction } from 'express';\n" : ''}${ts ? `
+declare module 'express-session' {
+  interface SessionData {
+    user?: { id: number; email: string };
+  }
+}
+` : ''}
 export const sessionConfig = {
   secret: process.env.SESSION_SECRET || 'your-session-secret-change-this',
   resave: false,
@@ -215,19 +248,20 @@ export const sessionConfig = {
     maxAge: 1000 * 60 * 60 * 24 * 7 // 7 days
   }
 };
-
-export function setupSession(app) {
+${helpers}
+export function setupSession(app${ts ? ': Express' : ''})${ts ? ': void' : ''} {
   app.use(session(sessionConfig));
 }
 
-export function authMiddleware(req, res, next) {
+export function authMiddleware(req${ts ? ': Request' : ''}, res${ts ? ': Response' : ''}, next${ts ? ': NextFunction' : ''})${ts ? ': void' : ''} {
   if (!req.session.user) {
-    return res.status(401).json({ error: 'Not authenticated' });
+    res.status(401).json({ error: 'Not authenticated' });
+    return;
   }
   next();
 }
 
-export function optionalAuth(req, res, next) {
+export function optionalAuth(_req${ts ? ': Request' : ''}, _res${ts ? ': Response' : ''}, next${ts ? ': NextFunction' : ''})${ts ? ': void' : ''} {
   // Session is always available, just proceed
   next();
 }
@@ -299,22 +333,25 @@ export async function optionalAuth(ctx, next) {
 /**
  * Generate authentication routes
  */
-export function generateAuthRoutes(runtime, authType) {
-  const userAccess = runtime === 'koa' ? 'ctx.state.user' : 'req.user';
-  const sessionUser = runtime === 'koa' ? 'ctx.session.user' : 'req.session.user';
+export function generateAuthRoutes(runtime, authType, language = 'javascript') {
+  const ts = language === 'typescript';
+  const credentialsCast = ts ? ' as { email?: string; name?: string; password?: string }' : '';
+  const loginCast = ts ? ' as { email?: string; password?: string }' : '';
+  // SQL models return snake_case rows; the Mongo model returns the document as-is.
+  const storedHash = 'user.password_hash ?? user.passwordHash';
 
   const jwtRoutes = {
     express: `
 import express from 'express';
-import { generateToken, authMiddleware } from '../middleware/auth.js';
+${ts ? "import type { Response, Router } from 'express';\n" : ''}import { generateToken, hashPassword, verifyPassword, authMiddleware${ts ? ', type AuthenticatedRequest' : ''} } from '../middleware/auth.js';
 import { UserModel } from '../db/models/User.js';
 
-const router = express.Router();
+const router${ts ? ': Router' : ''} = express.Router();
 
 // Register
 router.post('/register', async (req, res) => {
   try {
-    const { email, name, password } = req.body;
+    const { email, name, password } = req.body${credentialsCast};
 
     // Validate input
     if (!email || !name || !password) {
@@ -327,58 +364,63 @@ router.post('/register', async (req, res) => {
       return res.status(400).json({ error: 'User already exists' });
     }
 
-    // Create user (you should hash the password!)
-    const user = await UserModel.create({ email, name });
+    // Create user with a hashed password — never store the plain text
+    const passwordHash = await hashPassword(password);
+    const user = await UserModel.create({ email, name, passwordHash });
 
     // Generate token
     const token = generateToken({ id: user.id, email: user.email });
 
-    res.json({ user: { id: user.id, email: user.email, name: user.name }, token });
+    return res.json({ user: { id: user.id, email: user.email, name: user.name }, token });
   } catch (error) {
     console.error('Register error:', error);
-    res.status(500).json({ error: 'Registration failed' });
+    return res.status(500).json({ error: 'Registration failed' });
   }
 });
 
 // Login
 router.post('/login', async (req, res) => {
   try {
-    const { email, password } = req.body;
+    const { email, password } = req.body${loginCast};
 
     // Validate input
     if (!email || !password) {
       return res.status(400).json({ error: 'Missing required fields' });
     }
 
-    // Find user
+    // Find user and verify password (single 401 either way, so responses
+    // don't reveal which of the two failed)
     const user = await UserModel.findByEmail(email);
-    if (!user) {
+    const passwordOk = user && await verifyPassword(password, ${storedHash});
+    if (!passwordOk) {
       return res.status(401).json({ error: 'Invalid credentials' });
     }
-
-    // Verify password (you should implement proper password checking!)
 
     // Generate token
     const token = generateToken({ id: user.id, email: user.email });
 
-    res.json({ user: { id: user.id, email: user.email, name: user.name }, token });
+    return res.json({ user: { id: user.id, email: user.email, name: user.name }, token });
   } catch (error) {
     console.error('Login error:', error);
-    res.status(500).json({ error: 'Login failed' });
+    return res.status(500).json({ error: 'Login failed' });
   }
 });
 
 // Get current user
-router.get('/me', authMiddleware, async (req, res) => {
+router.get('/me', authMiddleware, async (req${ts ? ': AuthenticatedRequest' : ''}, res${ts ? ': Response' : ''}) => {
   try {
-    const user = await UserModel.findById(${userAccess}.id);
+    const authUser = req.user;
+    if (!authUser) {
+      return res.status(401).json({ error: 'Not authenticated' });
+    }
+    const user = await UserModel.findById(authUser.id);
     if (!user) {
       return res.status(404).json({ error: 'User not found' });
     }
-    res.json({ user: { id: user.id, email: user.email, name: user.name } });
+    return res.json({ user: { id: user.id, email: user.email, name: user.name } });
   } catch (error) {
     console.error('Get user error:', error);
-    res.status(500).json({ error: 'Failed to get user' });
+    return res.status(500).json({ error: 'Failed to get user' });
   }
 });
 
@@ -386,104 +428,91 @@ export default router;
 `,
     'built-in': `
 // Auth routes for built-in HTTP server
-import { generateToken, verifyToken } from '../middleware/auth.js';
+${ts ? "import type { IncomingMessage, ServerResponse } from 'node:http';\n" : ''}import { generateToken, verifyToken, hashPassword, verifyPassword } from '../middleware/auth.js';
 import { UserModel } from '../db/models/User.js';
 
 // Register handler
-export async function registerHandler(req, res) {
-  try {
-    // Parse JSON body
-    let body = '';
-    req.on('data', chunk => {
-      body += chunk.toString();
-    });
-    
-    req.on('end', async () => {
-      try {
-        const { email, name, password } = JSON.parse(body);
+export async function registerHandler(req${ts ? ': IncomingMessage' : ''}, res${ts ? ': ServerResponse' : ''}) {
+  let body = '';
+  req.on('data', chunk => {
+    body += chunk.toString();
+  });
 
-        // Validate input
-        if (!email || !name || !password) {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          return res.end(JSON.stringify({ error: 'Missing required fields' }));
-        }
+  req.on('end', async () => {
+    try {
+      const { email, name, password } = JSON.parse(body);
 
-        // Check if user exists
-        const existingUser = await UserModel.findByEmail(email);
-        if (existingUser) {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          return res.end(JSON.stringify({ error: 'User already exists' }));
-        }
-
-        // Create user (you should hash the password!)
-        const user = await UserModel.create({ email, name });
-
-        // Generate token
-        const token = generateToken({ id: user.id, email: user.email });
-
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ user: { id: user.id, email: user.email, name: user.name }, token }));
-      } catch (error) {
-        console.error('Register error:', error);
-        res.writeHead(500, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ error: 'Registration failed' }));
+      // Validate input
+      if (!email || !name || !password) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        return res.end(JSON.stringify({ error: 'Missing required fields' }));
       }
-    });
-  } catch (error) {
-    console.error('Register error:', error);
-    res.writeHead(500, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({ error: 'Registration failed' }));
-  }
+
+      // Check if user exists
+      const existingUser = await UserModel.findByEmail(email);
+      if (existingUser) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        return res.end(JSON.stringify({ error: 'User already exists' }));
+      }
+
+      // Create user with a hashed password — never store the plain text
+      const passwordHash = await hashPassword(password);
+      const user = await UserModel.create({ email, name, passwordHash });
+
+      // Generate token
+      const token = generateToken({ id: user.id, email: user.email });
+
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      return res.end(JSON.stringify({ user: { id: user.id, email: user.email, name: user.name }, token }));
+    } catch (error) {
+      console.error('Register error:', error);
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      return res.end(JSON.stringify({ error: 'Registration failed' }));
+    }
+  });
 }
 
 // Login handler
-export async function loginHandler(req, res) {
-  try {
-    // Parse JSON body
-    let body = '';
-    req.on('data', chunk => {
-      body += chunk.toString();
-    });
-    
-    req.on('end', async () => {
-      try {
-        const { email, password } = JSON.parse(body);
+export async function loginHandler(req${ts ? ': IncomingMessage' : ''}, res${ts ? ': ServerResponse' : ''}) {
+  let body = '';
+  req.on('data', chunk => {
+    body += chunk.toString();
+  });
 
-        // Validate input
-        if (!email || !password) {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          return res.end(JSON.stringify({ error: 'Missing required fields' }));
-        }
+  req.on('end', async () => {
+    try {
+      const { email, password } = JSON.parse(body);
 
-        // Find user
-        const user = await UserModel.findByEmail(email);
-        if (!user) {
-          res.writeHead(401, { 'Content-Type': 'application/json' });
-          return res.end(JSON.stringify({ error: 'Invalid credentials' }));
-        }
-
-        // Verify password (you should implement proper password checking!)
-
-        // Generate token
-        const token = generateToken({ id: user.id, email: user.email });
-
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ user: { id: user.id, email: user.email, name: user.name }, token }));
-      } catch (error) {
-        console.error('Login error:', error);
-        res.writeHead(500, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ error: 'Login failed' }));
+      // Validate input
+      if (!email || !password) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        return res.end(JSON.stringify({ error: 'Missing required fields' }));
       }
-    });
-  } catch (error) {
-    console.error('Login error:', error);
-    res.writeHead(500, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({ error: 'Login failed' }));
-  }
+
+      // Find user and verify password (single 401 either way, so responses
+      // don't reveal which of the two failed)
+      const user = await UserModel.findByEmail(email);
+      const passwordOk = user && await verifyPassword(password, ${storedHash});
+      if (!passwordOk) {
+        res.writeHead(401, { 'Content-Type': 'application/json' });
+        return res.end(JSON.stringify({ error: 'Invalid credentials' }));
+      }
+
+      // Generate token
+      const token = generateToken({ id: user.id, email: user.email });
+
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      return res.end(JSON.stringify({ user: { id: user.id, email: user.email, name: user.name }, token }));
+    } catch (error) {
+      console.error('Login error:', error);
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      return res.end(JSON.stringify({ error: 'Login failed' }));
+    }
+  });
 }
 
 // Get current user handler
-export async function meHandler(req, res) {
+export async function meHandler(req${ts ? ': IncomingMessage' : ''}, res${ts ? ': ServerResponse' : ''}) {
   try {
     // Verify token from Authorization header
     const authHeader = req.headers.authorization;
@@ -505,13 +534,13 @@ export async function meHandler(req, res) {
       res.writeHead(404, { 'Content-Type': 'application/json' });
       return res.end(JSON.stringify({ error: 'User not found' }));
     }
-    
+
     res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({ user: { id: user.id, email: user.email, name: user.name } }));
+    return res.end(JSON.stringify({ user: { id: user.id, email: user.email, name: user.name } }));
   } catch (error) {
     console.error('Get user error:', error);
     res.writeHead(500, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({ error: 'Failed to get user' }));
+    return res.end(JSON.stringify({ error: 'Failed to get user' }));
   }
 }
 
@@ -537,14 +566,14 @@ export function setupAuthRoutes() {
 }
 `,
     fastify: `
-import { generateToken } from '../plugins/auth.js';
+${ts ? "import type { FastifyInstance } from 'fastify';\n" : ''}import { generateToken, hashPassword, verifyPassword } from '../plugins/auth.js';
 import { UserModel } from '../db/models/User.js';
 
-export default async function authRoutes(fastify, options) {
+export default async function authRoutes(fastify${ts ? ': FastifyInstance' : ''})${ts ? ': Promise<void>' : ''} {
   // Register
   fastify.post('/register', async (request, reply) => {
     try {
-      const { email, name, password } = request.body;
+      const { email, name, password } = request.body${credentialsCast};
 
       // Validate input
       if (!email || !name || !password) {
@@ -557,15 +586,16 @@ export default async function authRoutes(fastify, options) {
         return reply.code(400).send({ error: 'User already exists' });
       }
 
-      // Create user (you should hash the password!)
-      const user = await UserModel.create({ email, name });
+      // Create user with a hashed password — never store the plain text
+      const passwordHash = await hashPassword(password);
+      const user = await UserModel.create({ email, name, passwordHash });
 
       // Generate token
       const token = generateToken({ id: user.id, email: user.email });
 
       return { user: { id: user.id, email: user.email, name: user.name }, token };
     } catch (error) {
-      fastify.log.error('Register error:', error);
+      fastify.log.error({ err: error }, 'Register error');
       return reply.code(500).send({ error: 'Registration failed' });
     }
   });
@@ -573,27 +603,27 @@ export default async function authRoutes(fastify, options) {
   // Login
   fastify.post('/login', async (request, reply) => {
     try {
-      const { email, password } = request.body;
+      const { email, password } = request.body${loginCast};
 
       // Validate input
       if (!email || !password) {
         return reply.code(400).send({ error: 'Missing required fields' });
       }
 
-      // Find user
+      // Find user and verify password (single 401 either way, so responses
+      // don't reveal which of the two failed)
       const user = await UserModel.findByEmail(email);
-      if (!user) {
+      const passwordOk = user && await verifyPassword(password, ${storedHash});
+      if (!passwordOk) {
         return reply.code(401).send({ error: 'Invalid credentials' });
       }
-
-      // Verify password (you should implement proper password checking!)
 
       // Generate token
       const token = generateToken({ id: user.id, email: user.email });
 
       return { user: { id: user.id, email: user.email, name: user.name }, token };
     } catch (error) {
-      fastify.log.error('Login error:', error);
+      fastify.log.error({ err: error }, 'Login error');
       return reply.code(500).send({ error: 'Login failed' });
     }
   });
@@ -603,13 +633,17 @@ export default async function authRoutes(fastify, options) {
     onRequest: [fastify.authenticate]
   }, async (request, reply) => {
     try {
-      const user = await UserModel.findById(request.user.id);
+      const authUser = request.user;
+      if (!authUser) {
+        return reply.code(401).send({ error: 'Not authenticated' });
+      }
+      const user = await UserModel.findById(authUser.id);
       if (!user) {
         return reply.code(404).send({ error: 'User not found' });
       }
       return { user: { id: user.id, email: user.email, name: user.name } };
     } catch (error) {
-      fastify.log.error('Get user error:', error);
+      fastify.log.error({ err: error }, 'Get user error');
       return reply.code(500).send({ error: 'Failed to get user' });
     }
   });
@@ -617,7 +651,7 @@ export default async function authRoutes(fastify, options) {
 `,
     koa: `
 import Router from '@koa/router';
-import { generateToken, authMiddleware } from '../middleware/auth.js';
+import { generateToken, hashPassword, verifyPassword, authMiddleware } from '../middleware/auth.js';
 import { UserModel } from '../db/models/User.js';
 
 const router = new Router();
@@ -625,7 +659,7 @@ const router = new Router();
 // Register
 router.post('/register', async (ctx) => {
   try {
-    const { email, name, password } = ctx.request.body;
+    const { email, name, password } = ctx.request.body${credentialsCast};
 
     // Validate input
     if (!email || !name || !password) {
@@ -642,8 +676,9 @@ router.post('/register', async (ctx) => {
       return;
     }
 
-    // Create user (you should hash the password!)
-    const user = await UserModel.create({ email, name });
+    // Create user with a hashed password — never store the plain text
+    const passwordHash = await hashPassword(password);
+    const user = await UserModel.create({ email, name, passwordHash });
 
     // Generate token
     const token = generateToken({ id: user.id, email: user.email });
@@ -659,7 +694,7 @@ router.post('/register', async (ctx) => {
 // Login
 router.post('/login', async (ctx) => {
   try {
-    const { email, password } = ctx.request.body;
+    const { email, password } = ctx.request.body${loginCast};
 
     // Validate input
     if (!email || !password) {
@@ -668,15 +703,15 @@ router.post('/login', async (ctx) => {
       return;
     }
 
-    // Find user
+    // Find user and verify password (single 401 either way, so responses
+    // don't reveal which of the two failed)
     const user = await UserModel.findByEmail(email);
-    if (!user) {
+    const passwordOk = user && await verifyPassword(password, ${storedHash});
+    if (!passwordOk) {
       ctx.status = 401;
       ctx.body = { error: 'Invalid credentials' };
       return;
     }
-
-    // Verify password (you should implement proper password checking!)
 
     // Generate token
     const token = generateToken({ id: user.id, email: user.email });
@@ -692,7 +727,13 @@ router.post('/login', async (ctx) => {
 // Get current user
 router.get('/me', authMiddleware, async (ctx) => {
   try {
-    const user = await UserModel.findById(${userAccess}.id);
+    const authUser = ctx.state.user;
+    if (!authUser) {
+      ctx.status = 401;
+      ctx.body = { error: 'Not authenticated' };
+      return;
+    }
+    const user = await UserModel.findById(authUser.id);
     if (!user) {
       ctx.status = 404;
       ctx.body = { error: 'User not found' };
@@ -713,15 +754,15 @@ export default router;
   const sessionRoutes = {
     express: `
 import express from 'express';
-import { authMiddleware } from '../middleware/auth.js';
+${ts ? "import type { Request, Response, Router } from 'express';\n" : ''}import { authMiddleware, hashPassword, verifyPassword } from '../middleware/auth.js';
 import { UserModel } from '../db/models/User.js';
 
-const router = express.Router();
+const router${ts ? ': Router' : ''} = express.Router();
 
 // Register
 router.post('/register', async (req, res) => {
   try {
-    const { email, name, password } = req.body;
+    const { email, name, password } = req.body${credentialsCast};
 
     if (!email || !name || !password) {
       return res.status(400).json({ error: 'Missing required fields' });
@@ -732,62 +773,71 @@ router.post('/register', async (req, res) => {
       return res.status(400).json({ error: 'User already exists' });
     }
 
-    const user = await UserModel.create({ email, name });
+    // Create user with a hashed password — never store the plain text
+    const passwordHash = await hashPassword(password);
+    const user = await UserModel.create({ email, name, passwordHash });
 
-    ${sessionUser} = { id: user.id, email: user.email };
+    req.session.user = { id: user.id, email: user.email };
 
-    res.json({ user: { id: user.id, email: user.email, name: user.name } });
+    return res.json({ user: { id: user.id, email: user.email, name: user.name } });
   } catch (error) {
     console.error('Register error:', error);
-    res.status(500).json({ error: 'Registration failed' });
+    return res.status(500).json({ error: 'Registration failed' });
   }
 });
 
 // Login
 router.post('/login', async (req, res) => {
   try {
-    const { email, password } = req.body;
+    const { email, password } = req.body${loginCast};
 
     if (!email || !password) {
       return res.status(400).json({ error: 'Missing required fields' });
     }
 
+    // Find user and verify password (single 401 either way, so responses
+    // don't reveal which of the two failed)
     const user = await UserModel.findByEmail(email);
-    if (!user) {
+    const passwordOk = user && await verifyPassword(password, ${storedHash});
+    if (!passwordOk) {
       return res.status(401).json({ error: 'Invalid credentials' });
     }
 
-    ${sessionUser} = { id: user.id, email: user.email };
+    req.session.user = { id: user.id, email: user.email };
 
-    res.json({ user: { id: user.id, email: user.email, name: user.name } });
+    return res.json({ user: { id: user.id, email: user.email, name: user.name } });
   } catch (error) {
     console.error('Login error:', error);
-    res.status(500).json({ error: 'Login failed' });
+    return res.status(500).json({ error: 'Login failed' });
   }
 });
 
 // Logout
-router.post('/logout', (req, res) => {
+router.post('/logout', (req${ts ? ': Request' : ''}, res${ts ? ': Response' : ''}) => {
   req.session.destroy((err) => {
     if (err) {
       return res.status(500).json({ error: 'Logout failed' });
     }
     res.clearCookie('connect.sid');
-    res.json({ message: 'Logged out successfully' });
+    return res.json({ message: 'Logged out successfully' });
   });
 });
 
 // Get current user
-router.get('/me', authMiddleware, async (req, res) => {
+router.get('/me', authMiddleware, async (req${ts ? ': Request' : ''}, res${ts ? ': Response' : ''}) => {
   try {
-    const user = await UserModel.findById(${sessionUser}.id);
+    const sessionUser = req.session.user;
+    if (!sessionUser) {
+      return res.status(401).json({ error: 'Not authenticated' });
+    }
+    const user = await UserModel.findById(sessionUser.id);
     if (!user) {
       return res.status(404).json({ error: 'User not found' });
     }
-    res.json({ user: { id: user.id, email: user.email, name: user.name } });
+    return res.json({ user: { id: user.id, email: user.email, name: user.name } });
   } catch (error) {
     console.error('Get user error:', error);
-    res.status(500).json({ error: 'Failed to get user' });
+    return res.status(500).json({ error: 'Failed to get user' });
   }
 });
 
@@ -850,12 +900,12 @@ SESSION_SECRET=your-session-secret-change-this-in-production
 /**
  * Generate complete auth scaffolding
  */
-export function generateAuthScaffolding(authType, runtime) {
+export function generateAuthScaffolding(authType, runtime, language = 'javascript') {
   const isJWT = authType === 'jwt';
 
   return {
-    middleware: isJWT ? generateJWTAuth(runtime) : generateSessionAuth(runtime),
-    routes: generateAuthRoutes(runtime, authType),
+    middleware: isJWT ? generateJWTAuth(runtime, language) : generateSessionAuth(runtime, language),
+    routes: generateAuthRoutes(runtime, authType, language),
     dependencies: getAuthDependencies(authType, runtime),
     env: generateAuthEnv(authType)
   };

--- a/packages/cli/src/generators/database-scaffold.js
+++ b/packages/cli/src/generators/database-scaffold.js
@@ -282,10 +282,16 @@ process.on('SIGINT', async () => {
 export function generateExampleModel(dbType, language = 'javascript') {
   const isTypeScript = language === 'typescript';
   const typeAnnotation = isTypeScript ? ': Promise<any>' : '';
+  const pUser = isTypeScript ? ': UserData' : '';
+  const pId = isTypeScript ? ': number' : '';
+  const pEmail = isTypeScript ? ': string' : '';
+  const pPartial = isTypeScript ? ': Partial<UserData>' : '';
   const interfaceDef = isTypeScript ? `
 interface UserData {
   email: string;
   name: string;
+  /** "scrypt:<salt>:<hash>" produced by the auth scaffold's hashPassword() */
+  passwordHash?: string;
 }` : '';
 
   const models = {
@@ -309,28 +315,28 @@ export class UserModel {
     \`);
   }
 
-  static async create(userData)${typeAnnotation} {
+  static async create(userData${pUser})${typeAnnotation} {
     const db = getDatabase();
     const result = await db.query(
-      'INSERT INTO users (email, name) VALUES ($1, $2) RETURNING *',
-      [userData.email, userData.name]
+      'INSERT INTO users (email, name, password_hash) VALUES ($1, $2, $3) RETURNING *',
+      [userData.email, userData.name, userData.passwordHash ?? null]
     );
     return result.rows[0];
   }
 
-  static async findById(id)${typeAnnotation} {
+  static async findById(id${pId})${typeAnnotation} {
     const db = getDatabase();
     const result = await db.query('SELECT * FROM users WHERE id = $1', [id]);
     return result.rows[0];
   }
 
-  static async findByEmail(email)${typeAnnotation} {
+  static async findByEmail(email${pEmail})${typeAnnotation} {
     const db = getDatabase();
     const result = await db.query('SELECT * FROM users WHERE email = $1', [email]);
     return result.rows[0];
   }
 
-  static async update(id, data)${typeAnnotation} {
+  static async update(id${pId}, data${pPartial})${typeAnnotation} {
     const db = getDatabase();
     const result = await db.query(
       'UPDATE users SET email = $1, name = $2, updated_at = CURRENT_TIMESTAMP WHERE id = $3 RETURNING *',
@@ -339,7 +345,7 @@ export class UserModel {
     return result.rows[0];
   }
 
-  static async delete(id)${typeAnnotation} {
+  static async delete(id${pId})${typeAnnotation} {
     const db = getDatabase();
     await db.query('DELETE FROM users WHERE id = $1', [id]);
   }
@@ -365,28 +371,28 @@ export class UserModel {
     \`);
   }
 
-  static async create(userData)${typeAnnotation} {
+  static async create(userData${pUser})${typeAnnotation} {
     const db = getDatabase();
     const result = await db.query(
-      'INSERT INTO users (email, name) VALUES (?, ?)',
-      [userData.email, userData.name]
+      'INSERT INTO users (email, name, password_hash) VALUES (?, ?, ?)',
+      [userData.email, userData.name, userData.passwordHash ?? null]
     );
     return result[0];
   }
 
-  static async findById(id)${typeAnnotation} {
+  static async findById(id${pId})${typeAnnotation} {
     const db = getDatabase();
     const result = await db.query('SELECT * FROM users WHERE id = ?', [id]);
     return result[0];
   }
 
-  static async findByEmail(email)${typeAnnotation} {
+  static async findByEmail(email${pEmail})${typeAnnotation} {
     const db = getDatabase();
     const result = await db.query('SELECT * FROM users WHERE email = ?', [email]);
     return result[0];
   }
 
-  static async update(id, data)${typeAnnotation} {
+  static async update(id${pId}, data${pPartial})${typeAnnotation} {
     const db = getDatabase();
     const result = await db.query(
       'UPDATE users SET email = ?, name = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?',
@@ -395,7 +401,7 @@ export class UserModel {
     return result[0];
   }
 
-  static async delete(id)${typeAnnotation} {
+  static async delete(id${pId})${typeAnnotation} {
     const db = getDatabase();
     await db.query('DELETE FROM users WHERE id = ?', [id]);
   }
@@ -418,34 +424,35 @@ export class UserModel {
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         email TEXT UNIQUE NOT NULL,
         name TEXT NOT NULL,
+        password_hash TEXT,
         created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
         updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
       )
     \`);
   }
 
-  static async create(data)${typeAnnotation} {
+  static async create(data${pUser})${typeAnnotation} {
     const db = getDatabase();
     await db.query(
-      'INSERT INTO users (email, name) VALUES (?, ?)',
-      [data.email, data.name]
+      'INSERT INTO users (email, name, password_hash) VALUES (?, ?, ?)',
+      [data.email, data.name, data.passwordHash ?? null]
     );
     return this.findByEmail(data.email);
   }
 
-  static async findById(id)${typeAnnotation} {
+  static async findById(id${pId})${typeAnnotation} {
     const db = getDatabase();
     const result = await db.query('SELECT * FROM users WHERE id = ?', [id]);
     return result.rows[0];
   }
 
-  static async findByEmail(email)${typeAnnotation} {
+  static async findByEmail(email${pEmail})${typeAnnotation} {
     const db = getDatabase();
     const result = await db.query('SELECT * FROM users WHERE email = ?', [email]);
     return result.rows[0];
   }
 
-  static async update(id, data)${typeAnnotation} {
+  static async update(id${pId}, data${pPartial})${typeAnnotation} {
     const db = getDatabase();
     await db.query(
       'UPDATE users SET email = ?, name = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?',
@@ -454,7 +461,7 @@ export class UserModel {
     return this.findById(id);
   }
 
-  static async delete(id)${typeAnnotation} {
+  static async delete(id${pId})${typeAnnotation} {
     const db = getDatabase();
     await db.query('DELETE FROM users WHERE id = ?', [id]);
   }
@@ -474,23 +481,23 @@ export class UserModel {
     await db.collection('users').createIndex({ email: 1 }, { unique: true });
   }
 
-  static async create(userData)${typeAnnotation} {
+  static async create(userData${pUser})${typeAnnotation} {
     const db = getDatabase();
     const result = await db.collection('users').insertOne(userData);
     return { _id: result.insertedId, ...userData };
   }
 
-  static async findById(id)${typeAnnotation} {
+  static async findById(id${pId})${typeAnnotation} {
     const db = getDatabase();
     return await db.collection('users').findOne({ _id: id });
   }
 
-  static async findByEmail(email)${typeAnnotation} {
+  static async findByEmail(email${pEmail})${typeAnnotation} {
     const db = getDatabase();
     return await db.collection('users').findOne({ email });
   }
 
-  static async update(id, data)${typeAnnotation} {
+  static async update(id${pId}, data${pPartial})${typeAnnotation} {
     const db = getDatabase();
     const result = await db.collection('users').updateOne(
       { _id: id },
@@ -499,7 +506,7 @@ export class UserModel {
     return result.modifiedCount > 0 ? this.findById(id) : null;
   }
 
-  static async delete(id)${typeAnnotation} {
+  static async delete(id${pId})${typeAnnotation} {
     const db = getDatabase();
     const result = await db.collection('users').deleteOne({ _id: id });
     return result.deletedCount > 0;

--- a/packages/cli/src/generators/database-scaffold.js
+++ b/packages/cli/src/generators/database-scaffold.js
@@ -286,6 +286,8 @@ export function generateExampleModel(dbType, language = 'javascript') {
   const pId = isTypeScript ? ': number' : '';
   const pEmail = isTypeScript ? ': string' : '';
   const pPartial = isTypeScript ? ': Partial<UserData>' : '';
+  const pUpdate = isTypeScript ? ": Pick<UserData, 'email' | 'name'>" : '';
+  const pIdMongo = isTypeScript ? ': string' : '';
   const interfaceDef = isTypeScript ? `
 interface UserData {
   email: string;
@@ -336,7 +338,7 @@ export class UserModel {
     return result.rows[0];
   }
 
-  static async update(id${pId}, data${pPartial})${typeAnnotation} {
+  static async update(id${pId}, data${pUpdate})${typeAnnotation} {
     const db = getDatabase();
     const result = await db.query(
       'UPDATE users SET email = $1, name = $2, updated_at = CURRENT_TIMESTAMP WHERE id = $3 RETURNING *',
@@ -377,28 +379,28 @@ export class UserModel {
       'INSERT INTO users (email, name, password_hash) VALUES (?, ?, ?)',
       [userData.email, userData.name, userData.passwordHash ?? null]
     );
-    return result[0];
+    return this.findById(result.insertId);
   }
 
   static async findById(id${pId})${typeAnnotation} {
     const db = getDatabase();
     const result = await db.query('SELECT * FROM users WHERE id = ?', [id]);
-    return result[0];
+    return result.rows[0];
   }
 
   static async findByEmail(email${pEmail})${typeAnnotation} {
     const db = getDatabase();
     const result = await db.query('SELECT * FROM users WHERE email = ?', [email]);
-    return result[0];
+    return result.rows[0];
   }
 
-  static async update(id${pId}, data${pPartial})${typeAnnotation} {
+  static async update(id${pId}, data${pUpdate})${typeAnnotation} {
     const db = getDatabase();
-    const result = await db.query(
+    await db.query(
       'UPDATE users SET email = ?, name = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?',
       [data.email, data.name, id]
     );
-    return result[0];
+    return this.findById(id);
   }
 
   static async delete(id${pId})${typeAnnotation} {
@@ -452,7 +454,7 @@ export class UserModel {
     return result.rows[0];
   }
 
-  static async update(id${pId}, data${pPartial})${typeAnnotation} {
+  static async update(id${pId}, data${pUpdate})${typeAnnotation} {
     const db = getDatabase();
     await db.query(
       'UPDATE users SET email = ?, name = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?',
@@ -487,7 +489,7 @@ export class UserModel {
     return { _id: result.insertedId, ...userData };
   }
 
-  static async findById(id${pId})${typeAnnotation} {
+  static async findById(id${pIdMongo})${typeAnnotation} {
     const db = getDatabase();
     return await db.collection('users').findOne({ _id: id });
   }
@@ -497,7 +499,7 @@ export class UserModel {
     return await db.collection('users').findOne({ email });
   }
 
-  static async update(id${pId}, data${pPartial})${typeAnnotation} {
+  static async update(id${pIdMongo}, data${pPartial})${typeAnnotation} {
     const db = getDatabase();
     const result = await db.collection('users').updateOne(
       { _id: id },
@@ -506,7 +508,7 @@ export class UserModel {
     return result.modifiedCount > 0 ? this.findById(id) : null;
   }
 
-  static async delete(id${pId})${typeAnnotation} {
+  static async delete(id${pIdMongo})${typeAnnotation} {
     const db = getDatabase();
     const result = await db.collection('users').deleteOne({ _id: id });
     return result.deletedCount > 0;

--- a/packages/cli/src/generators/project-scaffold.js
+++ b/packages/cli/src/generators/project-scaffold.js
@@ -92,7 +92,9 @@ export async function scaffoldProject(projectPath, options) {
   // Generate main server file
   const serverContent = generateServerFile(runtime, {
     port: 3000,
-    hasApi: packages.includes('api') || auth,
+    // hasApi gates the './api/routes.js' import, which only exists when the
+    // api package was selected — auth has its own routes file and hasAuth flag.
+    hasApi: packages.includes('api'),
     hasDatabase: !!database,
     hasAuth: !!auth,
     isTypeScript
@@ -151,7 +153,7 @@ export async function scaffoldProject(projectPath, options) {
 
   // Generate auth scaffolding
   if (auth) {
-    const authScaffolding = generateAuthScaffolding(auth, runtime);
+    const authScaffolding = generateAuthScaffolding(auth, runtime, language);
 
     // Write auth middleware/plugin
     const authDir = runtime === 'fastify' ? 'plugins' : 'middleware';
@@ -274,8 +276,10 @@ function generatePackageJson(name, options) {
     Object.assign(base.devDependencies, getRuntimeTypeDependencies(runtime));
 
     // Add @types for auth packages if auth is enabled
-    if (auth) {
+    if (auth === 'jwt') {
       base.devDependencies['@types/jsonwebtoken'] = '^9.0.7';
+    } else if (auth === 'session') {
+      base.devDependencies['@types/express-session'] = '^1.18.0';
     }
   }
 
@@ -298,7 +302,7 @@ function generatePackageJson(name, options) {
 
   // Auth dependencies
   if (auth) {
-    const { dependencies: authDeps } = generateAuthScaffolding(auth, runtime);
+    const { dependencies: authDeps } = generateAuthScaffolding(auth, runtime, language);
     Object.assign(base.dependencies, authDeps);
   }
 

--- a/packages/cli/src/generators/runtime-scaffold.js
+++ b/packages/cli/src/generators/runtime-scaffold.js
@@ -12,7 +12,7 @@ const cliVersion = getCLIVersion();
  * Generate built-in HTTP server setup
  */
 export function generateBuiltInServer(options = {}) {
-  const { port = 3000, hasApi = false, hasDatabase = false, hasAuth = false } = options;
+  const { port = 3000, hasApi = false, hasDatabase = false, hasAuth = false, isTypeScript = false } = options;
 
   const imports = [
     `import http from 'node:http';`,
@@ -72,7 +72,7 @@ ${hasApi || hasAuth ? `  // Handle API routes
     try {
       const content = await fs.promises.readFile(filePath);
       const ext = path.extname(filePath).toLowerCase();
-      const contentTypes = {
+      const contentTypes${isTypeScript ? ': Record<string, string>' : ''} = {
         '.html': 'text/html',
         '.js': 'text/javascript',
         '.css': 'text/css',
@@ -114,7 +114,7 @@ ${hasApi || hasAuth ? `  // Handle API routes
 });
 
 ${hasApi || hasAuth ? `// Route matching helper
-function matchRoute(routePattern, urlPath, requestMethod, routeMethod) {
+function matchRoute(routePattern${isTypeScript ? ': string' : ''}, urlPath${isTypeScript ? ': string' : ''}, requestMethod${isTypeScript ? ': string | undefined' : ''}, routeMethod${isTypeScript ? ': string' : ''}) {
   // Check HTTP method
   if (requestMethod !== routeMethod) {
     return null;
@@ -129,12 +129,16 @@ function matchRoute(routePattern, urlPath, requestMethod, routeMethod) {
     return null;
   }
 
-  const params = {};
+  const params${isTypeScript ? ': Record<string, string>' : ''} = {};
 
   // Match each segment
   for (let i = 0; i < routeSegments.length; i++) {
     const routeSegment = routeSegments[i];
     const urlSegment = urlSegments[i];
+
+    if (routeSegment === undefined || urlSegment === undefined) {
+      return null;
+    }
 
     // Check for parameter (e.g., :id)
     if (routeSegment.startsWith(':')) {

--- a/scripts/scaffold-boot-e2e.mjs
+++ b/scripts/scaffold-boot-e2e.mjs
@@ -46,9 +46,17 @@ const PERMUTATIONS = [
       packages: ['api', 'i18n', 'forms', 'seo', 'testing']
     },
     port: 4314
+  },
+  {
+    name: 'js-built-in-auth-sqlite',
+    options: { language: 'javascript', runtime: 'built-in', packages: [], database: 'sqlite', auth: 'jwt' },
+    port: 4315
+  },
+  {
+    name: 'ts-express-auth-sqlite',
+    options: { language: 'typescript', runtime: 'express', packages: ['api'], database: 'sqlite', auth: 'jwt' },
+    port: 4316
   }
-  // TODO(v1.1): fullstack + database + auth permutations once the tracked
-  // auth-scaffold gaps (password hashing, built-in setupAuthRoutes) close.
 ];
 
 function run(cmd, args, opts = {}) {
@@ -138,6 +146,42 @@ async function bootAndProbe(projectPath, permutation) {
       const postBody = await postRes.json();
       if (postBody.name !== 'Ada') {
         throw new Error(`POST /api/users returned ${JSON.stringify(postBody)}`);
+      }
+    }
+
+    if (permutation.options.auth === 'jwt') {
+      const base = `http://127.0.0.1:${port}/api/auth`;
+      const postJson = (path, payload) =>
+        fetch(`${base}${path}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+
+      const regRes = await postJson('/register', { email: 'ada@example.com', name: 'Ada', password: 'correct horse' });
+      const regBody = await regRes.json();
+      if (!regRes.ok || !regBody.token) {
+        throw new Error(`register failed (${regRes.status}): ${JSON.stringify(regBody)}`);
+      }
+
+      const loginRes = await postJson('/login', { email: 'ada@example.com', password: 'correct horse' });
+      const loginBody = await loginRes.json();
+      if (!loginRes.ok || !loginBody.token) {
+        throw new Error(`login with correct password failed (${loginRes.status}): ${JSON.stringify(loginBody)}`);
+      }
+
+      // The regression this suite exists for: login must actually check the password.
+      const badRes = await postJson('/login', { email: 'ada@example.com', password: 'wrong password' });
+      if (badRes.status !== 401) {
+        throw new Error(`login with WRONG password returned ${badRes.status} — password is not being verified`);
+      }
+
+      const meRes = await fetch(`${base}/me`, {
+        headers: { Authorization: `Bearer ${loginBody.token}` }
+      });
+      const meBody = await meRes.json();
+      if (!meRes.ok || meBody.user?.email !== 'ada@example.com') {
+        throw new Error(`GET /me failed (${meRes.status}): ${JSON.stringify(meBody)}`);
       }
     }
   } catch (error) {


### PR DESCRIPTION
## Summary

Closes the biggest v1 blocker: **generated auth was an authentication bypass**. Register handlers discarded the password (the template literally said `// Create user (you should hash the password!)`), and login handlers issued a valid JWT for *any* password on a known email.

### Fixed
- **Real password hashing**: register hashes with scrypt (`node:crypto` — zero new dependencies; stored as `scrypt:<salt>:<hash>`), login verifies with `timingSafeEqual` and returns a single 401 for both unknown-email and wrong-password. Applied across all four runtimes (express, fastify, koa, built-in), JWT and session flavors.
- **Database models store the hash**: postgres/mysql had a `password_hash` column that `create()` never wrote; sqlite lacked the column entirely. The TS `UserData` interface gained `passwordHash`.
- **TypeScript auth/database scaffolds typecheck**: previously TS + auth or TS + database failed `tsc --noEmit` outright (implicit-any parameters everywhere, untyped `jwt.sign` expiresIn, non-portable express `Router` inference, pino-incompatible `fastify.log.error`, strict errors in the built-in route matcher). All templates now emit annotations when the project is TypeScript — verified for express/fastify/koa/built-in × JWT plus express × session.
- **Auth-only scaffolds boot**: `hasApi` conflated "api package selected" with "has auth", so auth without the api package imported a nonexistent `./api/routes.js` and crashed at startup.
- **Session auth restricted to express** — the only runtime with session routes; other runtimes previously got an empty routes file.

### Added
- Boot E2E auth permutations (`js-built-in-auth-sqlite`, `ts-express-auth-sqlite`): register → login → **wrong password must 401** → `/me` with the issued token. This also finally exercises the built-in `setupAuthRoutes` wiring and a database permutation in CI, closing the TODO tracked since rc.2.

## Test plan
- [x] TS typecheck matrix: express/fastify/koa/built-in × jwt + express × session — all pass (all failed before)
- [x] Scaffold boot E2E: all 6 permutations install, typecheck, test, boot, and pass HTTP probes — including the wrong-password 401 regression probe
- [x] CLI vitest suite: 114 tests pass; root lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Authentication scaffolding now securely hashes passwords and supports password verification for JWT and session-based login flows.
  - Generated database models now store password hashes and include user deletion support.
  - TypeScript projects receive improved authentication and database typings.
  - Added authentication boot checks covering registration, login, invalid passwords, and authenticated profile access.

- **Bug Fixes**
  - Session authentication is now offered only for Express projects.
  - Fixed auth-only projects failing to start and corrected generated routing and configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->