### PR TITLE
chore!: drop CJS bundles — all packages are ESM-only

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Primary packages (examples, not exhaustive):
 
 ## Environment & Tooling Requirements
 
-- Use Node 20+ only.
+- Use Node 22.12+ only (the `engines` floor of every package).
 - Use pnpm for all installs and scripts; do not use npm/yarn.
 - ESM only: prefer `import`/`export`; avoid `require()` outside of `dist/*` or scripts that explicitly support CJS.
 - Respect conditional exports: `@coherent.js/core` maps `development` to `./src/index.js` and production to `./dist/*`. Dev tooling may import from `src` directly.
@@ -123,14 +123,15 @@ Safety/operational constraints:
 
 ## @coherent.js/core Specifics
 
-- Conditional exports:
+- Conditional exports (ESM-only since 1.0.0-rc.6 — no `development` condition,
+  it pointed at unshipped `src/` and broke Vite/Vitest consumers; no CJS
+  bundles, node >=22.12 serves `require()` via native require(esm)):
   ```json
   {
     "exports": {
       ".": {
-        "development": "./src/index.js",
-        "import": "./dist/index.js",
-        "require": "./dist/index.cjs"
+        "types": "./types/index.d.ts",
+        "default": "./dist/index.js"
       }
     }
   }
@@ -176,7 +177,7 @@ pnpm website:dev
 ## Do / Don't Checklist
 
 Do:
-- Use Node 20+, pnpm, and ESM imports.
+- Use Node 22.12+, pnpm, and ESM imports.
 - Prefer package-scoped tests for focused runs.
 - Keep tests hermetic; use shims for browser APIs.
 - Maintain consistent code style and follow `eslint.config.js` rules.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **ESM-only packaging.** All published packages dropped their CommonJS bundles; export maps resolve `types` + `default` to the ESM build. Node >= 22.12 loads these through `require()` natively, so CJS consumers keep working — while the dual-package hazard (two module instances of the client event registry / state stores when an app mixed `import` and `require`) is gone, and the `require` condition of api/core/database no longer points at bundles TypeScript had no declarations for (the original `.d.cts` gap: the ESM-flavored `.d.ts` was lying about the CJS entry). Also fixed along the way: the other packages' export maps used the `import` condition alone, so `require()` of them failed with `ERR_PACKAGE_PATH_NOT_EXPORTED` even on require(esm)-capable Node. TypeScript CJS consumers need TS 5.8+ with `--module nodenext`; see MIGRATION-1.0.md.
+- **`engines.node` floor raised to `>=22.12.0`** — the LTS patch where require(esm) shipped unflagged.
+- Legacy `buildAll`/`generatePackageExports` helpers deleted from `scripts/shared-build.mjs` (referenced packages that no longer exist; nothing invoked them).
+
 ### Fixed
 
 - **Auth scaffolds actually authenticate.** Generated register handlers silently discarded the password (`// you should hash the password!`) and login handlers issued a valid JWT for **any** password on a known email — an authentication bypass in every generated project. Registration now hashes with scrypt (Node's built-in KDF — zero new dependencies; stored as `scrypt:<salt>:<hash>`) and login verifies with `timingSafeEqual`, across all four runtimes (express, fastify, koa, built-in), both JWT and session flavors. The database models gained the matching `password_hash` column/insert (it existed but was never written for postgres/mysql, and was missing entirely for sqlite).

--- a/MIGRATION-1.0.md
+++ b/MIGRATION-1.0.md
@@ -40,6 +40,26 @@ See the quick-scan table below for the full list with one-line fixes. The remain
 | `@coherent.js/forms/forms` subpath export removed | Source file is gone |
 | `@coherent.js/forms/advanced-validation` subpath export removed | Source file is gone |
 | `createFormBuilder({ fields: [...] })` now actually registers passed fields | Previously a silent no-op; this is a bugfix that may surprise callers who relied on the no-op behavior — but no such caller is known |
+| CJS bundles removed — all packages are ESM-only | `require('@coherent.js/*')` still works on Node >= 22.12 via native require(esm). TypeScript CJS consumers need TS 5.8+ with `--module nodenext`. Bundlers are unaffected. |
+| `engines.node` floor raised to `>=22.12.0` | 22.12 is the LTS patch where require(esm) shipped unflagged |
+
+---
+
+## ESM-only packaging
+
+The published packages no longer ship CommonJS bundles (`dist/*.cjs`). Every
+export map now resolves `types` + `default` to the ESM build.
+
+Why: Node >= 22.12 loads ESM through `require()` natively, so the CJS copies
+only added weight and the classic dual-package hazard — an app importing ESM
+while a dependency requires CJS would get **two** module instances (two client
+event registries, two state stores) with subtly broken behavior.
+
+What you need:
+
+- **Node consumers** (`import` or `require`): Node >= 22.12 — nothing else.
+- **TypeScript CJS projects**: TypeScript 5.8+ with `--module nodenext`.
+- **Bundlers** (vite/webpack/rollup/esbuild): unaffected; they consume ESM.
 
 ---
 

--- a/PUBLISHING_GUIDE.md
+++ b/PUBLISHING_GUIDE.md
@@ -167,12 +167,11 @@ Each package should follow this structure:
   "version": "1.0.0-beta.1",
   "description": "PACKAGE_DESCRIPTION",
   "type": "module",
-  "main": "./src/index.js",
+  "main": "./dist/index.js",
   "exports": {
     ".": {
-      "development": "./src/index.js",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "types": "./types/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "packageManager": "pnpm@11.15.0",
   "engines": {
-    "node": ">=22.0.0",
+    "node": ">=22.12.0",
     "pnpm": ">=8.0.0"
   },
   "workspaces": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -3,34 +3,28 @@
   "version": "1.0.0-rc.5",
   "description": "API framework for Coherent.js (REST/RPC/GraphQL).",
   "type": "module",
-  "main": "dist/index.cjs",
+  "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "./types/index.d.ts",
   "exports": {
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
     "./router": {
-      "import": "./dist/router.js",
-      "require": "./dist/router.cjs"
+      "default": "./dist/router.js"
     },
     "./middleware": {
-      "import": "./dist/middleware.js",
-      "require": "./dist/middleware.cjs"
+      "default": "./dist/middleware.js"
     },
     "./security": {
-      "import": "./dist/security.js",
-      "require": "./dist/security.cjs"
+      "default": "./dist/security.js"
     },
     "./validation": {
-      "import": "./dist/validation.js",
-      "require": "./dist/validation.cjs"
+      "default": "./dist/validation.js"
     },
     "./serialization": {
-      "import": "./dist/serialization.js",
-      "require": "./dist/serialization.cjs"
+      "default": "./dist/serialization.js"
     }
   },
   "scripts": {
@@ -50,7 +44,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.12.0"
   },
   "license": "MIT",
   "repository": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,6 +12,7 @@
   },
   "exports": {
     ".": {
+      "types": "./types/index.d.ts",
       "default": "./dist/index.js"
     },
     "./build-tools": "./src/build-tools/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,7 +12,7 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/index.js"
+      "default": "./dist/index.js"
     },
     "./build-tools": "./src/build-tools/index.js",
     "./build-tools/vite": "./src/build-tools/vite.js",
@@ -40,7 +40,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.12.0"
   },
   "dependencies": {
     "chokidar": "5.0.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -8,19 +8,19 @@
   "exports": {
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/index.js"
+      "default": "./dist/index.js"
     },
     "./events": {
       "types": "./types/events.d.ts",
-      "import": "./dist/events/index.js"
+      "default": "./dist/events/index.js"
     },
     "./router": {
       "types": "./types/router.d.ts",
-      "import": "./dist/router.js"
+      "default": "./dist/router.js"
     },
     "./hmr": {
       "types": "./types/hmr.d.ts",
-      "import": "./dist/hmr.js"
+      "default": "./dist/hmr.js"
     }
   },
   "types": "./types/index.d.ts",
@@ -41,7 +41,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.12.0"
   },
   "license": "MIT",
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,14 +3,13 @@
   "version": "1.0.0-rc.5",
   "description": "Core runtime for Coherent.js (SSR framework).",
   "type": "module",
-  "main": "dist/index.cjs",
+  "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "./types/index.d.ts",
   "exports": {
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "default": "./dist/index.js"
     }
   },
   "scripts": {
@@ -30,7 +29,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.12.0"
   },
   "license": "MIT",
   "repository": {

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -3,30 +3,25 @@
   "version": "1.0.0-rc.5",
   "description": "Database utilities and adapters for Coherent.js",
   "type": "module",
-  "main": "dist/index.cjs",
+  "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "./types/index.d.ts",
   "exports": {
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
     "./model": {
-      "import": "./dist/model.js",
-      "require": "./dist/model.cjs"
+      "default": "./dist/model.js"
     },
     "./migration": {
-      "import": "./dist/migration.js",
-      "require": "./dist/migration.cjs"
+      "default": "./dist/migration.js"
     },
     "./connection": {
-      "import": "./dist/connection-manager.js",
-      "require": "./dist/connection-manager.cjs"
+      "default": "./dist/connection-manager.js"
     },
     "./middleware": {
-      "import": "./dist/middleware.js",
-      "require": "./dist/middleware.cjs"
+      "default": "./dist/middleware.js"
     }
   },
   "scripts": {
@@ -46,7 +41,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.12.0"
   },
   "license": "MIT",
   "repository": {

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -8,40 +8,40 @@
   "exports": {
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./dist/index.js"
+      "default": "./dist/index.js"
     },
     "./visualizer": {
-      "import": "./dist/component-visualizer.js"
+      "default": "./dist/component-visualizer.js"
     },
     "./performance": {
-      "import": "./dist/performance/index.js"
+      "default": "./dist/performance/index.js"
     },
     "./performance/cache": {
-      "import": "./dist/performance/cache.js"
+      "default": "./dist/performance/cache.js"
     },
     "./performance/code-splitting": {
-      "import": "./dist/performance/code-splitting.js"
+      "default": "./dist/performance/code-splitting.js"
     },
     "./performance/lazy-loading": {
-      "import": "./dist/performance/lazy-loading.js"
+      "default": "./dist/performance/lazy-loading.js"
     },
     "./performance/dashboard": {
-      "import": "./dist/performance-dashboard.js"
+      "default": "./dist/performance-dashboard.js"
     },
     "./errors": {
-      "import": "./dist/enhanced-errors.js"
+      "default": "./dist/enhanced-errors.js"
     },
     "./hybrid": {
-      "import": "./dist/hybrid-integration-tools.js"
+      "default": "./dist/hybrid-integration-tools.js"
     },
     "./inspector": {
-      "import": "./dist/inspector.js"
+      "default": "./dist/inspector.js"
     },
     "./profiler": {
-      "import": "./dist/profiler.js"
+      "default": "./dist/profiler.js"
     },
     "./logger": {
-      "import": "./dist/logger.js"
+      "default": "./dist/logger.js"
     },
     "./package.json": "./package.json"
   },
@@ -82,7 +82,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.12.0"
   },
   "sideEffects": false
 }

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -44,7 +44,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.12.0"
   },
   "types": "./types/index.d.ts",
   "files": [

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -43,7 +43,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.12.0"
   },
   "types": "./types/index.d.ts",
   "files": [

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -6,27 +6,27 @@
   "exports": {
     "./express": {
       "types": "./types/express/index.d.ts",
-      "import": "./src/express/index.js"
+      "default": "./src/express/index.js"
     },
     "./fastify": {
       "types": "./types/fastify/index.d.ts",
-      "import": "./src/fastify/index.js"
+      "default": "./src/fastify/index.js"
     },
     "./koa": {
-      "import": "./src/koa/index.js"
+      "default": "./src/koa/index.js"
     },
     "./nextjs": {
       "types": "./types/nextjs/index.d.ts",
-      "import": "./src/nextjs/index.js"
+      "default": "./src/nextjs/index.js"
     },
     "./astro": {
-      "import": "./src/astro/index.js"
+      "default": "./src/astro/index.js"
     },
     "./remix": {
-      "import": "./src/remix/index.js"
+      "default": "./src/remix/index.js"
     },
     "./sveltekit": {
-      "import": "./src/sveltekit/index.js"
+      "default": "./src/sveltekit/index.js"
     }
   },
   "files": [
@@ -43,7 +43,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.12.0"
   },
   "license": "MIT",
   "repository": {

--- a/packages/seo/package.json
+++ b/packages/seo/package.json
@@ -43,7 +43,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.12.0"
   },
   "types": "./types/index.d.ts",
   "files": [

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -44,7 +44,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.12.0"
   },
   "scripts": {
     "build": "node build.mjs",

--- a/packages/tooling/package.json
+++ b/packages/tooling/package.json
@@ -8,27 +8,27 @@
   "exports": {
     ".": {
       "types": "./types/testing/index.d.ts",
-      "import": "./dist/testing/index.js"
+      "default": "./dist/testing/index.js"
     },
     "./testing": {
       "types": "./types/testing/index.d.ts",
-      "import": "./dist/testing/index.js"
+      "default": "./dist/testing/index.js"
     },
     "./testing/renderer": {
       "types": "./types/testing/renderer.d.ts",
-      "import": "./dist/testing/test-renderer.js"
+      "default": "./dist/testing/test-renderer.js"
     },
     "./testing/utils": {
       "types": "./types/testing/utils.d.ts",
-      "import": "./dist/testing/test-utils.js"
+      "default": "./dist/testing/test-utils.js"
     },
     "./testing/matchers": {
       "types": "./types/testing/matchers.d.ts",
-      "import": "./dist/testing/matchers.js"
+      "default": "./dist/testing/matchers.js"
     },
     "./lsp": {
       "types": "./dist/lsp/server.d.ts",
-      "import": "./dist/lsp/server.js"
+      "default": "./dist/lsp/server.js"
     }
   },
   "bin": {
@@ -90,7 +90,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=22.12.0"
   },
   "sideEffects": false
 }

--- a/scripts/shared-build.mjs
+++ b/scripts/shared-build.mjs
@@ -50,10 +50,11 @@ function findNearestManifest(entryPoint) {
 }
 
 /**
- * Build a package with both ESM and CJS formats.
+ * Build a package (ESM only — the published packages dropped their CJS
+ * bundles for 1.0; node >=22.12 supports require(esm) natively).
  *
  * Pass `entries` ({ name: 'src/file.js', ... }) when the package's exports map
- * declares subpaths — every name is built to `<outDir>/<name>.js`/`.cjs`.
+ * declares subpaths — every name is built to `<outDir>/<name>.js`.
  */
 export async function buildPackage({
   packageName,
@@ -61,8 +62,7 @@ export async function buildPackage({
   entries,
   outDir = 'dist',
   external = [],
-  additionalConfig = {},
-  formats = ['esm', 'cjs'] // Allow specifying which formats to build
+  additionalConfig = {}
 }) {
   const manifest = JSON.parse(await readFile(findNearestManifest(entries ? Object.values(entries)[0] : entryPoint), 'utf-8'));
   const config = {
@@ -80,25 +80,12 @@ export async function buildPackage({
   const entryMap = entries ?? { index: entryPoint };
 
   for (const [name, src] of Object.entries(entryMap)) {
-    // Build ESM version
-    if (formats.includes('esm')) {
-      await build({
-        ...config,
-        entryPoints: [src],
-        format: 'esm',
-        outfile: `${outDir}/${name}.js`,
-      });
-    }
-
-    // Build CJS version (only for Node.js packages)
-    if (formats.includes('cjs')) {
-      await build({
-        ...config,
-        entryPoints: [src],
-        format: 'cjs',
-        outfile: `${outDir}/${name}.cjs`,
-      });
-    }
+    await build({
+      ...config,
+      entryPoints: [src],
+      format: 'esm',
+      outfile: `${outDir}/${name}.js`,
+    });
   }
 
   console.log(`✅ Built ${packageName} successfully`);
@@ -163,127 +150,4 @@ export async function buildBrowserPackage({
   }
 
   console.log(`✅ Built browser package ${packageName} successfully`);
-}
-
-/**
- * Generate package.json for built packages with correct exports
- */
-export async function generatePackageExports(packagePath) {
-  const packageJsonPath = path.join(packagePath, 'package.json');
-  const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf-8'));
-
-  // Ensure consistent exports configuration
-  packageJson.exports = {
-    ".": {
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs",
-      "types": "./dist/index.d.ts"
-    }
-  };
-
-  // Ensure files array includes dist
-  if (!packageJson.files) {
-    packageJson.files = [];
-  }
-  if (!packageJson.files.includes('dist/')) {
-    packageJson.files.unshift('dist/');
-  }
-
-  await writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2) + '\n');
-}
-
-/**
- * Build all packages in dependency order
- */
-export async function buildAll() {
-  const buildOrder = [
-    'core',
-    'api',
-    'database',
-    'client',
-    'integrations',
-    'fastify',
-    'koa',
-    'nextjs'
-  ];
-
-  // First pass: Build JavaScript bundles
-  for (const pkg of buildOrder) {
-    try {
-      const packagePath = `packages/${pkg}`;
-      const entryPoint = `${packagePath}/${getEntryPoint(pkg)}`;
-
-      if (pkg === 'client') {
-        await buildBrowserPackage({
-          packageName: `@coherent.js/${pkg}`,
-          entryPoint: entryPoint,
-          outDir: `${packagePath}/dist`
-        });
-      } else {
-        await buildPackage({
-          packageName: `@coherent.js/${pkg}`,
-          entryPoint: entryPoint,
-          outDir: `${packagePath}/dist`,
-          external: getPackageExternals(pkg)
-        });
-      }
-
-      await generatePackageExports(packagePath);
-    } catch (error) {
-      console.error(`❌ Failed to build ${pkg}:`, error);
-      process.exit(1);
-    }
-  }
-
-  // Second pass: Generate TypeScript declarations
-  console.log('🔧 Generating TypeScript declarations...');
-  try {
-    await generateDeclarations('.');
-  } catch (error) {
-    console.warn('⚠️  TypeScript declaration generation failed:', error.message);
-    console.log('📝 Continuing without type declarations...');
-  }
-
-  console.log('🎉 All packages built successfully!');
-}
-
-/**
- * Get entry point for each package
- */
-function getEntryPoint(packageName) {
-  const entryPoints = {
-    'core': 'src/index.js',
-    'api': 'src/index.js',
-    'database': 'src/index.js',
-    'client': 'src/index.js',
-    'integrations': 'src/express/index.js',
-    'fastify': 'src/index.js',
-    'koa': 'src/index.js',
-    'nextjs': 'src/index.js'
-  };
-
-  return entryPoints[packageName] || `src/index.js`;
-}
-
-/**
- * Get package-specific externals
- */
-function getPackageExternals(packageName) {
-  const externals = {
-    'core': [],
-    'api': ['@coherent.js/core'],
-    'database': ['@coherent.js/core'],
-    'client': ['@coherent.js/core'],
-    'integrations': ['@coherent.js/core'],
-    'fastify': ['@coherent.js/core'],
-    'koa': ['@coherent.js/core'],
-    'nextjs': ['@coherent.js/core']
-  };
-
-  return externals[packageName] || [];
-}
-
-// If run directly, build all packages
-if (import.meta.url === `file://${process.argv[1]}`) {
-  buildAll().catch(console.error);
 }


### PR DESCRIPTION
## Summary

Resolves the tracked `.d.cts` decision — the last packaging call before 1.0.0. Instead of adding CJS-flavored declarations, this removes the CJS side entirely.

**Why ESM-only:**
- Engines already require modern Node, and **Node ≥ 22.12 loads ESM through `require()` natively** — CJS consumers keep working with zero bundles shipped for them.
- It eliminates the **dual-package hazard**: with both formats published, an app importing ESM while a dependency requires CJS gets two module instances — two client event registries, two state stores — with subtly broken behavior. The client package's singletons made this a real risk, not a theoretical one.
- The original gap this decision tracked (`require` conditions pointing at `.cjs` bundles whose only types were ESM-flavored `.d.ts`) disappears rather than needing a second declaration set to maintain.

**What changed:**
- api/core/database: `require` conditions + `dist/*.cjs` outputs removed; `main` → ESM entry.
- **All packages: the ESM loader condition is now `default` instead of `import`.** This fixes a live bug found while verifying: with `import`-only maps, `require()` failed with `ERR_PACKAGE_PATH_NOT_EXPORTED` even on require(esm)-capable Node — so CJS consumers were already locked out of most packages.
- `shared-build.mjs`: CJS branch removed; bit-rotted `buildAll`/`generatePackageExports` helpers deleted (referenced packages that no longer exist; nothing invoked them).
- `engines.node` floor: `>=22.12.0` (the LTS patch where require(esm) shipped unflagged).
- MIGRATION-1.0.md gained an ESM-only section: TS CJS projects need TS 5.8+ with `--module nodenext`; bundlers unaffected.

## Test plan
- [x] Packed the ESM-only core and verified from a scratch consumer: `require('@coherent.js/core')` renders HTML from CommonJS, `import` works from ESM
- [x] publint: all 12 packages "All good!"
- [x] api-surface and bundle-size gates unchanged
- [x] 1691 tests, Playwright e2e, all 6 scaffold boot permutations pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changed**
  - Packages are now distributed as ESM-only, with streamlined exports and no CommonJS bundles.
  - The minimum supported Node.js version is now 22.12.0.
  - `require()` compatibility is supported through Node.js native ESM behavior.

- **Documentation**
  - Added migration guidance for ESM-only packaging.
  - Updated publishing and developer guidance with the new runtime and module requirements.
  - Clarified TypeScript and bundler considerations for upgrading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->