### PR TITLE
fix(tsconfig): reference project configs by file path

### DIFF
--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -13,6 +13,6 @@
     "src/**/*"
   ],
   "references": [
-    { "path": "../core" }
+    { "path": "../core/tsconfig.json" }
   ]
 }

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -16,6 +16,6 @@
     "src/**/*"
   ],
   "references": [
-    { "path": "../core" }
+    { "path": "../core/tsconfig.json" }
   ]
 }

--- a/packages/database/tsconfig.json
+++ b/packages/database/tsconfig.json
@@ -13,6 +13,6 @@
     "src/**/*"
   ],
   "references": [
-    { "path": "../core" }
+    { "path": "../core/tsconfig.json" }
   ]
 }

--- a/packages/devtools/tsconfig.json
+++ b/packages/devtools/tsconfig.json
@@ -13,6 +13,6 @@
     "src/**/*"
   ],
   "references": [
-    { "path": "../core" }
+    { "path": "../core/tsconfig.json" }
   ]
 }

--- a/packages/forms/tsconfig.json
+++ b/packages/forms/tsconfig.json
@@ -13,6 +13,6 @@
     "src/**/*"
   ],
   "references": [
-    { "path": "../core" }
+    { "path": "../core/tsconfig.json" }
   ]
 }

--- a/packages/i18n/tsconfig.json
+++ b/packages/i18n/tsconfig.json
@@ -13,6 +13,6 @@
     "src/**/*"
   ],
   "references": [
-    { "path": "../core" }
+    { "path": "../core/tsconfig.json" }
   ]
 }

--- a/packages/seo/tsconfig.json
+++ b/packages/seo/tsconfig.json
@@ -13,6 +13,6 @@
     "src/**/*"
   ],
   "references": [
-    { "path": "../core" }
+    { "path": "../core/tsconfig.json" }
   ]
 }

--- a/packages/state/tsconfig.json
+++ b/packages/state/tsconfig.json
@@ -13,6 +13,6 @@
     "src/**/*"
   ],
   "references": [
-    { "path": "../core" }
+    { "path": "../core/tsconfig.json" }
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,17 @@
 {
   "files": [],
   "references": [
-    { "path": "./packages/core" },
-    { "path": "./packages/api" },
-    { "path": "./packages/database" },
-    { "path": "./packages/client" },
-    { "path": "./packages/integrations" },
-    { "path": "./packages/forms" },
-    { "path": "./packages/i18n" },
-    { "path": "./packages/seo" },
-    { "path": "./packages/tooling" },
-    { "path": "./packages/devtools" },
-    { "path": "./packages/cli" },
-    { "path": "./packages/state" },
+    { "path": "./packages/core/tsconfig.json" },
+    { "path": "./packages/api/tsconfig.json" },
+    { "path": "./packages/database/tsconfig.json" },
+    { "path": "./packages/client/tsconfig.json" },
+    { "path": "./packages/integrations/tsconfig.json" },
+    { "path": "./packages/forms/tsconfig.json" },
+    { "path": "./packages/i18n/tsconfig.json" },
+    { "path": "./packages/seo/tsconfig.json" },
+    { "path": "./packages/tooling/tsconfig.json" },
+    { "path": "./packages/devtools/tsconfig.json" },
+    { "path": "./packages/cli/tsconfig.json" },
+    { "path": "./packages/state/tsconfig.json" }
   ]
 }


### PR DESCRIPTION
## Summary

The Playwright E2E job has been failing on `main` since the `@playwright/test` 1.61.1 → 1.62.0 bump in #125. Playwright 1.62.0 cannot resolve TypeScript project references written in directory form, so `playwright test` aborted before running a single test. This points every reference at the config file directly, which Playwright accepts and TypeScript treats identically.

## Changes

- `tsconfig.json` — all 12 project references now use the `./packages/<name>/tsconfig.json` form; also drops a trailing comma that made the file invalid strict JSON
- `packages/{api,client,database,devtools,forms,i18n,seo,state}/tsconfig.json` — same change to the nested `../core` references, since Playwright walks references recursively and would have failed on those next

### Root cause

Playwright's tsconfig loader appends `.json` when the path does not already end in it (`playwright/lib/common/index.js`, `resolveConfigFile`):

```js
if (!referencedConfigFile.endsWith(".json")) referencedConfigFile += ".json";
```

So `"./packages/core"` resolved to `packages/core.json` rather than `packages/core/tsconfig.json`:

```
Failed to load tsconfig file at tsconfig.json:
Failed to resolve "references" path "./packages/core"
```

This is an upstream Playwright bug — the directory form is valid TypeScript and the same config passed under 1.61.1 — but it blocks the job either way, and the file form is a clean fix that costs us nothing.

## Test Plan

- [x] Existing tests pass (`pnpm test`) — via pre-commit hook and CI on Node 22.x/24.x/26.x
- [x] Lint passes (`pnpm lint`)
- [ ] New tests added for new functionality — N/A, build-config fix with no new functionality
- [x] Manually verified the change works — reproduced the failure locally first, then `pnpm run e2e` 6/6 passed; `pnpm run typecheck` clean; `tsc --build --dry` resolves all 12 projects

CI on this branch is green across all 5 jobs, including the previously failing Playwright E2E.

## Checklist

- [x] Code follows the project's ESM-only style — N/A, JSON config only
- [x] No `eval()` or `new Function()` introduced
- [x] Documentation updated if API changed — N/A, no API change
- [x] Changeset added if this affects published packages — N/A, dev-time build config only, no runtime or published output change

## Notes

- Dependabot PR #124 was red only because of this bug; it should go green once this lands and it rebases.
- Unrelated, not addressed here: the checked-in `packages/vscode-extension/server/` artifacts drift on rebuild (a `vscode-languageserver` update changed the emitted import specifier from `node` to `node.js`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved TypeScript project reference resolution across the codebase.
  * Builds now use explicit package configuration files for more reliable project compilation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->