### PR TITLE
fix(core): forward component access through a Proxy and reuse trusted markers

### DIFF
--- a/packages/cli/src/commands/build.js
+++ b/packages/cli/src/commands/build.js
@@ -87,14 +87,9 @@ export function hasCoherentDependency(startDir) {
 }
 
 /**
- * Package managers this command is willing to invoke.
- *
- * detectPackageManager() must only ever return a member of this set. The
- * result is interpolated into a shell command, and `packageManager` comes
- * from a package.json that may not be trustworthy — a value like
- * `"x; rm -rf ~ ;@1"` would otherwise execute on `coherent build`. Matching
- * against a fixed set means the interpolated value is always one of four
- * literals, never attacker-controlled text.
+ * detectPackageManager() must only return a member of this set: the result is
+ * interpolated into a shell command and `packageManager` comes from a
+ * package.json that may be hostile.
  */
 const SUPPORTED_PACKAGE_MANAGERS = new Set(['npm', 'pnpm', 'yarn', 'bun']);
 
@@ -106,8 +101,6 @@ export function detectPackageManager(startDir) {
     if (typeof declared === 'string') {
       // corepack format: "<name>@<version>[+hash]"
       const name = declared.split('@')[0].trim().toLowerCase();
-      // An unrecognised name is ignored rather than trusted, so detection
-      // falls through to the lockfiles below.
       if (SUPPORTED_PACKAGE_MANAGERS.has(name)) return name;
     }
 
@@ -168,9 +161,8 @@ export const buildCommand = new Command('build')
 
       if (buildScript && !isSelfReferential(buildScript)) {
         spinner.text = `Running build script with ${packageManager}...`;
-        // Safe to interpolate: detectPackageManager() only returns a member of
-        // SUPPORTED_PACKAGE_MANAGERS. shell:true is kept because npm/pnpm/yarn
-        // are .cmd shims on Windows and are not directly executable.
+        // shell:true is safe here: packageManager is allowlisted, and the
+        // binaries are .cmd shims on Windows.
         execSync(`${packageManager} run build`, {
           stdio: options.watch ? 'inherit' : 'pipe',
           cwd: process.cwd(),

--- a/packages/core/src/components/component-system.js
+++ b/packages/core/src/components/component-system.js
@@ -453,49 +453,62 @@ export function createComponent(definition) {
     }
 
     const instance = new Component(definition);
+    const callable = (props = {}) => instance.render(props);
 
-    // Calling the component renders it with the supplied props. This is the
-    // contract the docs, the READMEs and the CLI generators all rely on:
-    //   render(Counter({ count: 2 }))
-    const component = (props = {}) => instance.render(props);
-
-    // Lifecycle methods return `this` purely for chaining, so hand back the
-    // callable rather than the bare instance to keep the chain callable.
+    // Lifecycle methods return `this` for chaining; hand back the proxy.
     const CHAINABLE = new Set(['mount', 'update', 'destroy']);
 
-    // Expose the Component API on the callable. Methods stay bound to the
-    // instance because COMPONENT_METADATA is keyed by instance identity.
-    Object.getOwnPropertyNames(Component.prototype).forEach(key => {
-        if (key === 'constructor' || typeof instance[key] !== 'function') return;
-
-        component[key] = CHAINABLE.has(key)
-            ? (...args) => {
-                instance[key](...args);
-                return component;
+    // A Proxy rather than a one-time key copy: `mounted() { this.timerId = x }`
+    // runs after this returns, and a snapshot would never see it.
+    return new Proxy(callable, {
+        get(target, key, receiver) {
+            if (key === 'clone') {
+                return (overrides = {}) =>
+                    createComponent({...instance.definition, ...overrides});
             }
-            : instance[key].bind(instance);
+
+            const value = Reflect.get(instance, key, instance);
+
+            if (typeof value === 'function') {
+                return CHAINABLE.has(key)
+                    ? (...args) => {
+                        value.apply(instance, args);
+                        return receiver;
+                    }
+                    // COMPONENT_METADATA is keyed by instance identity, so
+                    // `this` must be the instance, never the proxy.
+                    : value.bind(instance);
+            }
+
+            return value !== undefined || Reflect.has(instance, key)
+                ? value
+                : Reflect.get(target, key, receiver);
+        },
+
+        set(target, key, value) {
+            return Reflect.set(instance, key, value, instance);
+        },
+
+        has(target, key) {
+            return Reflect.has(instance, key) || Reflect.has(target, key);
+        },
+
+        deleteProperty(target, key) {
+            return Reflect.deleteProperty(instance, key);
+        },
+
+        ownKeys() {
+            return Reflect.ownKeys(instance);
+        },
+
+        getOwnPropertyDescriptor(target, key) {
+            const descriptor = Reflect.getOwnPropertyDescriptor(instance, key);
+            // Proxy invariant: reported own keys must be configurable.
+            return descriptor
+                ? {...descriptor, configurable: true}
+                : Reflect.getOwnPropertyDescriptor(target, key);
+        }
     });
-
-    // Cloning a callable component yields another callable component.
-    component.clone = (overrides = {}) =>
-        createComponent({...instance.definition, ...overrides});
-
-    // Mirror instance properties (name, props, state, children, computed
-    // getters, user-defined methods, ...) so reads and writes reach the
-    // instance. defineProperty is required because a function's own `name`
-    // and `length` are not writable.
-    Object.keys(instance).forEach(key => {
-        Object.defineProperty(component, key, {
-            get: () => instance[key],
-            set: value => {
-                instance[key] = value;
-            },
-            enumerable: true,
-            configurable: true
-        });
-    });
-
-    return component;
 }
 
 /**

--- a/packages/core/src/rendering/html-renderer.js
+++ b/packages/core/src/rendering/html-renderer.js
@@ -163,6 +163,12 @@ class HTMLRenderer extends BaseRenderer {
             return '';
         }
 
+        // Before cycle tracking: a marker is an inert leaf, so the same one
+        // may appear twice without that being a cycle.
+        if (isTrustedContent(component)) {
+            return component.__html;
+        }
+
         // Detect circular references (objects only)
         if (typeof component === 'object' && component !== null && !Array.isArray(component)) {
             if (options.seenObjects && options.seenObjects.has(component)) {
@@ -180,11 +186,6 @@ class HTMLRenderer extends BaseRenderer {
 
         // Use base class depth validation
         this.validateDepth(depth);
-
-        // Content marked by dangerouslySetInnerContent() is emitted verbatim.
-        if (isTrustedContent(component)) {
-            return component.__html;
-        }
 
         try {
             // Use base class component type processing
@@ -671,7 +672,6 @@ export async function* renderToStream(component, options = {}) {
         if (typeof comp === 'object') {
             for (const [tagName, props] of Object.entries(comp)) {
                 if (typeof props === 'object' && props !== null) {
-                    // `html` is raw content, not an attribute.
                     const { children, text, html: rawHtml, ...attributes } = props;
                     const attrsStr = formatAttributes(attributes);
                     const openTag = attrsStr ? `<${tagName} ${attrsStr}>` : `<${tagName}>`;

--- a/packages/core/test/components.test.js
+++ b/packages/core/test/components.test.js
@@ -119,6 +119,27 @@ describe('createComponent returns a callable component', () => {
     expect(render(clone({ className: 'z' }))).toBe('<div class="eyebrow z"></div>');
   });
 
+  it('exposes properties a lifecycle hook assigns after construction', () => {
+    const component = createComponent({
+      name: 'Timer',
+      render: () => ({ div: {} }),
+      mounted() { this.timerId = 42; }
+    });
+
+    component.mount();
+
+    expect(component.timerId).toBe(42);
+  });
+
+  it('writes through to the instance for new keys', () => {
+    const component = Eyebrow();
+
+    component.late = 'value';
+
+    expect(component.late).toBe('value');
+    expect('late' in component).toBe(true);
+  });
+
   it('accepts an object definition as before', () => {
     const Titled = createComponent({
       name: 'Titled',

--- a/packages/core/test/trusted-content.test.js
+++ b/packages/core/test/trusted-content.test.js
@@ -62,6 +62,21 @@ describe('dangerouslySetInnerContent', () => {
     }
   });
 
+  // A marker is an inert leaf, so reusing one is not a cycle.
+  it('renders the same marker more than once', () => {
+    const marker = dangerouslySetInnerContent(RAW);
+
+    expect(render({ div: { children: [marker, marker] } }))
+      .toBe(`<div>${RAW}${RAW}</div>`);
+  });
+
+  it('still detects genuine circular references', () => {
+    const node = { div: { children: [] } };
+    node.div.children.push(node);
+
+    expect(() => render(node)).toThrow(/[Cc]ircular/);
+  });
+
   it('still escapes untrusted strings', () => {
     expect(render({ div: { text: RAW } })).toBe('<div>&lt;em&gt;bold&lt;/em&gt;</div>');
   });


### PR DESCRIPTION
Two defects CodeRabbit found on #127, which merged before the fixes landed. Both are still on `main`.

## Instance properties assigned after construction were invisible

`createComponent()` copied the instance's keys once, at creation time. Anything a lifecycle hook assigned later got no accessor, because hooks run *after* `createComponent` returns:

```js
const Timer = createComponent({
  name: 'Timer',
  render: () => ({ div: {} }),
  mounted() { this.timerId = 42; }
});
Timer.mount();
Timer.timerId;   // undefined — the instance held 42
```

Silent, and it breaks the documented contract that the callable mirrors instance fields. Storing a handle in `mounted()` to clean up in `destroyed()` is the obvious way to hit it.

Replaced the snapshot with a `Proxy` that forwards reads and writes dynamically, which also removes the two key-copying loops. Methods stay bound to the instance — `COMPONENT_METADATA` is keyed by instance identity, so `this` must never be the proxy — and `mount`/`update`/`destroy` still return the callable so chaining works.

## A reused trusted marker was rejected as a circular reference

The `dangerouslySetInnerContent` short-circuit ran *after* circular-reference tracking, so the first use recorded the marker in `seenObjects` and the second was treated as a cycle:

```js
const t = dangerouslySetInnerContent('<em>x</em>');
render({ div: { children: [t, t] } });
// RenderingError: Circular reference detected in component tree
```

A marker is an inert leaf holding a string, so it can legitimately appear more than once. Moved the check ahead of the tracking. Genuine cycles are still detected — there's a test for that.

## Testing

Four regression tests: post-construction property, write-through for new keys, reused marker, and genuine cycles still throwing. 1792 pass, lint clean, both typechecks clean, API surface unchanged.
