### PR TITLE
chore(release): add the 1.0.1 changeset

### DIFF
--- a/.changeset/eighty-donkeys-argue.md
+++ b/.changeset/eighty-donkeys-argue.md
@@ -1,0 +1,49 @@
+---
+"@coherent.js/forms": patch
+"@coherent.js/core": patch
+"@coherent.js/state": patch
+"@coherent.js/seo": patch
+"@coherent.js/i18n": patch
+"@coherent.js/devtools": patch
+"@coherent.js/tooling": patch
+"@coherent.js/integrations": patch
+"@coherent.js/client": patch
+"@coherent.js/cli": patch
+---
+
+Make published type declarations match the runtime.
+
+`@coherent.js/forms` 1.0.0 could not build a usable form: `buildForm()`
+returned the builder where its declaration promised a `CoherentNode`, the
+`<form>` element dropped `action`, `method` and `name`, `toHTML()` emitted a
+near-empty form with unescaped labels, and `setAction`, `setMethod`, `build`
+and `render` were declared but absent. Fields typed `textarea` and `select`
+also rendered as `<input type="textarea">` and `<input type="select">`, which
+are not valid controls — they are now `<textarea>` and `<select>` elements.
+
+The same drift ran through nine packages. `seo.MetaBuilder` declared
+`setTitle`/`setDescription`/`setCanonical` against an implementation of
+`title`/`description`/`canonical`; `state.Observable` declared
+`get`/`set`/`subscribe` against `value`/`watch`/`unwatch`; `i18n.Translator`
+declared `translate`/`addMessages` against `t`/`addTranslations`; and
+`devtools.DevTools` declared `enable`/`disable`/`getReport`, which exist
+nowhere. Each of those packages was unusable from TypeScript in the same way
+`forms` was. The declarations now follow the implementations.
+
+The reverse gap is closed too: 69 real exports no TypeScript user could see,
+including core's event bus, lifecycle, error boundaries and object factory,
+cli's commands, and client's event-delegation classes.
+
+Also fixed:
+
+- `forms.registerValidator()` was a no-op. Two modules export a const named
+  `validators` and the star export shadowed one of them, so registrations
+  never reached the object consumers get.
+- `@coherent.js/state` now exports `FormState`, `ListState`, `ModalState`,
+  `RouterState`, `StateError` and `globalErrorHandler`, all of which were
+  declared but unreachable.
+- `integrations/express` declares `createExpressIntegration` and
+  `expressEngine`.
+
+A CI gate now compares each package's declarations against its runtime exports
+at every published entry point, so this class of defect cannot ship again.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coherent.js/monorepo",
-  "version": "1.0.0-rc.6",
+  "version": "1.0.1",
   "private": true,
   "description": "A lightweight, high-performance server-side rendering framework using pure JavaScript objects. Features include streaming renderer, performance monitoring, component composition, memoization, and integrations with Express.js, Fastify, and Next.js.",
   "type": "module",


### PR DESCRIPTION
Everything merged in #132 is unreleased — npm still serves `1.0.0`, which carries the broken declarations across nine packages, the forms builder bug, `<input type="textarea">`, and 28 vulnerable transitive dependencies including a critical `tar` advisory.

## What this does

Adds the changeset for a patch release. `changeset status` resolves it to all twelve packages: the ten that changed, plus `api` and `database`, which the `fixed` group in `.changeset/config.json` carries along.

```
@coherent.js/{forms,core,state,seo,i18n,devtools,tooling,integrations,client,cli}  1.0.1   (explicit)
@coherent.js/{api,database}                                                        1.0.1   (fixed group)
```

Also moves the root manifest from `1.0.0-rc.6` to `1.0.1`. It sat at the prerelease number through the whole 1.0.0 release. Nothing published reads it — `shared-build.mjs` injects each package’s **own** manifest version into `__COHERENT_VERSION__`, which I verified by rebuilding and checking `core.VERSION` still reports `1.0.0` — but carrying a stale prerelease number into a patch release is confusing.

## One judgment call worth flagging

This is typed as a **patch**, per the version you asked for. Two changes in the release are arguably additive rather than corrective:

- `@coherent.js/state` now exports `FormState`, `ListState`, `ModalState`, `RouterState`, `StateError` and `globalErrorHandler`
- `@coherent.js/forms` renders `textarea` and `select` fields as real elements

Both were declared-but-missing APIs rather than new features — the types already promised them — so patch is defensible. Flagging it since strict semver would read new exports as minor.

## Verification

Build, lint, 1823 tests. `changeset status` output checked against the twelve expected packages.

After merge, publishing is triggered either by a published GitHub release or `workflow_dispatch` on the publish workflow with the `latest` tag.