### PR TITLE
fix(forms): make the builder emit a form that works without JavaScript

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
-  "//": "linked, not fixed: on @changesets/cli 2.31.1 a fixed group silently escalates a minor bump to a major (a minor resolved to 2.0.0). linked keeps released packages version-synced without that.",
+  "//": "linked, not fixed, plus onlyUpdatePeerDependentsWhenOutOfRange: nine packages peerDepend on @coherent.js/core, and changesets majors a peer dependent whenever its peer bumps. With peer ranges pinned as workspace:* that was right — the published range was an exact version — so every minor resolved to a major. Peer ranges are workspace:^ now, so a core minor stays in range and this option stops the escalation.",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
   "fixed": [],
@@ -12,5 +12,8 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": [],
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,11 +1,14 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
+  "//": "linked, not fixed: on @changesets/cli 2.31.1 a fixed group silently escalates a minor bump to a major (a minor resolved to 2.0.0). linked keeps released packages version-synced without that.",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [
-    ["@coherent.js/*"]
+  "fixed": [],
+  "linked": [
+    [
+      "@coherent.js/*"
+    ]
   ],
-  "linked": [],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",

--- a/.changeset/olive-poems-shine.md
+++ b/.changeset/olive-poems-shine.md
@@ -1,5 +1,16 @@
 ---
 "@coherent.js/forms": minor
+"@coherent.js/core": minor
+"@coherent.js/state": minor
+"@coherent.js/seo": minor
+"@coherent.js/i18n": minor
+"@coherent.js/devtools": minor
+"@coherent.js/tooling": minor
+"@coherent.js/integrations": minor
+"@coherent.js/client": minor
+"@coherent.js/cli": minor
+"@coherent.js/api": minor
+"@coherent.js/database": minor
 ---
 
 Let the form builder express a production form.
@@ -50,3 +61,9 @@ string values render as inline handlers, which would reintroduce per field the
 script this release stopped emitting on the form.
 
 Controls also no longer carry an empty `class=""` or `placeholder=""`.
+
+Peer ranges on workspace packages move from `workspace:*` to `workspace:^`.
+`workspace:*` publishes as an exact pin — `@coherent.js/forms@1.0.1` required
+`@coherent.js/core` at exactly `1.0.1` — so upgrading any one package
+conflicted with every other, and every release had to move all twelve in
+lockstep. `^` lets a consumer take a core minor without republishing the rest.

--- a/.changeset/olive-poems-shine.md
+++ b/.changeset/olive-poems-shine.md
@@ -38,8 +38,15 @@ builder.field('website', {
 });
 ```
 
-**Hidden fields are no longer rendered.** `buildForm()` ignored `visible: false`
-and `showWhen`, while `validate()` had always skipped them — so a conditionally
-hidden field rendered but was never validated. Both now agree.
+**Hidden fields are no longer rendered or validated.** `buildForm()` ignored
+`visible: false` and `showWhen`, while `validate()` skipped only `showWhen` —
+so a conditionally hidden field rendered but was never validated, and a
+`visible: false` field could block submission with an error for a control that
+was never on the page. Both now use one predicate, and `visible: false` is
+final rather than something a truthy `showWhen` can override.
+
+Attributes named `on*` are refused: they are syntactically valid names whose
+string values render as inline handlers, which would reintroduce per field the
+script this release stopped emitting on the form.
 
 Controls also no longer carry an empty `class=""` or `placeholder=""`.

--- a/.changeset/olive-poems-shine.md
+++ b/.changeset/olive-poems-shine.md
@@ -1,0 +1,45 @@
+---
+"@coherent.js/forms": minor
+---
+
+Let the form builder express a production form.
+
+**Forms work without JavaScript again.** `buildForm()` emitted
+`onsubmit="handleSubmit(event)"` on every form — naming a global the package
+never defines, since `hydrateForm` binds its own listener — plus `novalidate`,
+which turns off the browser validation a no-JS submission depends on.
+`novalidate: false` was ignored. Both are now off by default: the form posts to
+its `action` and validates natively with JavaScript disabled. Opt back in with
+`enhance: true` (or a handler string) and `novalidate: true`. This also stops
+the builder emitting markup that a strict CSP blocks.
+
+**`attributes` is honoured.** It was declared on `FormField` and read by
+nothing, so `autocomplete`, `maxlength`, `tabindex` and `data-*` were silently
+dropped. Attributes are applied before the builder's own, so `name`, `id`,
+`type` and the `aria-*` pair cannot be overridden, and names that are not valid
+HTML attribute names are rejected — `formatAttributes` escapes attribute values
+but interpolates names raw. `disabled` and `readonly` are honoured too.
+
+**Class names are yours.** A `classNames` option covers the wrapper, label,
+control, invalid state, error message and submit button, defaulting to the
+previous values and exported as `DEFAULT_CLASS_NAMES`. Per-field `className`
+appends to the control class. `hydrateForm` now finds the field wrapper through
+the `data-field` attribute the builder already emitted rather than
+`.form-field`, and takes the same `classNames` so the classes it writes on
+failure match what the server rendered.
+
+Together these make a honeypot a plain field, with no dedicated API:
+
+```js
+builder.field('website', {
+  label: 'Website',
+  className: 'contact-form__trap',
+  attributes: { tabindex: '-1', autocomplete: 'off' }
+});
+```
+
+**Hidden fields are no longer rendered.** `buildForm()` ignored `visible: false`
+and `showWhen`, while `validate()` had always skipped them — so a conditionally
+hidden field rendered but was never validated. Both now agree.
+
+Controls also no longer carry an empty `class=""` or `placeholder=""`.

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -56,7 +56,7 @@
     "url": "https://github.com/Tomdrouv1/coherent.js/issues"
   },
   "peerDependencies": {
-    "@coherent.js/core": "workspace:*"
+    "@coherent.js/core": "workspace:^"
   },
   "devDependencies": {
     "@coherent.js/state": "workspace:*"

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -54,7 +54,7 @@
   },
   "peerDependencies": {
     "sqlite3": ">=5.0.0",
-    "@coherent.js/core": "workspace:*"
+    "@coherent.js/core": "workspace:^"
   },
   "peerDependenciesMeta": {
     "sqlite3": {

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -69,7 +69,7 @@
     "typecheck": "tsc -p tsconfig.typecheck.json --noEmit"
   },
   "peerDependencies": {
-    "@coherent.js/core": "workspace:*"
+    "@coherent.js/core": "workspace:^"
   },
   "repository": {
     "type": "git",

--- a/packages/forms/api-surface.txt
+++ b/packages/forms/api-surface.txt
@@ -6,6 +6,7 @@
 # Package: @coherent.js/forms
 
 == . ==
+DEFAULT_CLASS_NAMES
 FormBuilder
 FormValidator
 buildForm
@@ -20,6 +21,7 @@ validateForm
 validators
 
 == ./form-builder ==
+DEFAULT_CLASS_NAMES
 FormBuilder
 buildForm
 createFormBuilder

--- a/packages/forms/bundle-size.json
+++ b/packages/forms/bundle-size.json
@@ -1,5 +1,5 @@
 {
   "package": "@coherent.js/forms",
-  "raw": 35741,
-  "gz": 7392
+  "raw": 38254,
+  "gz": 8172
 }

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -30,8 +30,8 @@
     "typecheck": "tsc -p tsconfig.typecheck.json --noEmit"
   },
   "peerDependencies": {
-    "@coherent.js/core": "workspace:*",
-    "@coherent.js/state": "workspace:*"
+    "@coherent.js/core": "workspace:^",
+    "@coherent.js/state": "workspace:^"
   },
   "repository": {
     "type": "git",

--- a/packages/forms/src/form-builder.js
+++ b/packages/forms/src/form-builder.js
@@ -9,6 +9,50 @@
 import { render as renderToHTML } from '@coherent.js/core';
 
 /**
+ * Class applied to each structural slot. Consumers override any subset via
+ * the `classNames` option; hydrateForm accepts `invalid` and `error` so the
+ * client writes the same names the server rendered.
+ */
+export const DEFAULT_CLASS_NAMES = {
+  /** Wrapper around label, control and error */
+  field: 'form-field',
+  label: '',
+  /** Base class on the control, before any per-field className */
+  control: '',
+  /** Added to the control while it has a visible error */
+  invalid: 'error',
+  /** The error message element */
+  error: 'error-message',
+  submit: 'submit-button'
+};
+
+/**
+ * Attribute names are interpolated into the markup unescaped by
+ * formatAttributes, so a passthrough has to reject anything that is not a
+ * plain name — otherwise `{'x onclick=alert(1)': ''}` injects an attribute.
+ */
+const VALID_ATTRIBUTE_NAME = /^[A-Za-z_:][-A-Za-z0-9_:.]*$/;
+
+function safeAttributes(attributes) {
+  if (!attributes || typeof attributes !== 'object') return {};
+
+  const safe = {};
+  for (const [name, value] of Object.entries(attributes)) {
+    if (VALID_ATTRIBUTE_NAME.test(name)) {
+      safe[name] = value;
+    } else {
+      console.warn(`[coherent.js/forms] Ignoring invalid attribute name: ${JSON.stringify(name)}`);
+    }
+  }
+  return safe;
+}
+
+/** Join class names, dropping empties so no element carries `class=""`. */
+function joinClasses(...names) {
+  return names.filter(Boolean).join(' ');
+}
+
+/**
  * Form Builder
  * Helps create form components with validation
  */
@@ -370,7 +414,7 @@ export class FormBuilder {
   /**
    * Build input component with validation metadata for hydration
    */
-  buildInput(name) {
+  buildInput(name, classNames = this.resolveClassNames()) {
     const field = this.fields.get(name);
     if (!field) return null;
 
@@ -388,16 +432,28 @@ export class FormBuilder {
       .filter(Boolean)
       .join(',');
 
+    const controlClass = joinClasses(
+      classNames.control,
+      field.className,
+      error && isTouched ? classNames.invalid : null
+    );
+
     const inputProps = {
+      // Spread first: name, id, type and the aria-* pair below are the
+      // builder's own invariants, and hydration keys off them.
+      ...safeAttributes(field.attributes),
       type: field.type,
       name: field.name,
       id: field.name,
       value: value,
-      placeholder: field.placeholder,
       'aria-invalid': error ? 'true' : 'false',
-      'aria-describedby': error ? `${name}-error` : undefined,
-      className: error && isTouched ? 'error' : ''
+      'aria-describedby': error ? `${name}-error` : undefined
     };
+
+    if (field.placeholder) inputProps.placeholder = field.placeholder;
+    if (controlClass) inputProps.className = controlClass;
+    if (field.disabled) inputProps.disabled = true;
+    if (field.readonly) inputProps.readonly = true;
 
     // Add validation metadata for client-side hydration
     if (field.required) {
@@ -451,89 +507,86 @@ export class FormBuilder {
   /**
    * Build label component
    */
-  buildLabel(name) {
+  buildLabel(name, classNames = this.resolveClassNames()) {
     const field = this.fields.get(name);
     if (!field) return null;
 
-    return {
-      label: {
-        for: field.name,
-        text: field.label
-      }
-    };
+    const props = { for: field.name, text: field.label };
+    if (classNames.label) props.className = classNames.label;
+
+    return { label: props };
   }
 
   /**
    * Build error component
    */
-  buildError(name) {
+  buildError(name, classNames = this.resolveClassNames()) {
     const error = this.errors[name];
     const isTouched = this.touched[name];
 
     if (!error || !isTouched) return null;
 
-    return {
-      div: {
-        id: `${name}-error`,
-        className: 'error-message',
-        role: 'alert',
-        text: error
-      }
-    };
+    const props = { id: `${name}-error`, role: 'alert', text: error };
+    if (classNames.error) props.className = classNames.error;
+
+    return { div: props };
+  }
+
+  /**
+   * Merge configured class names over the defaults
+   */
+  resolveClassNames(overrides = {}) {
+    return { ...DEFAULT_CLASS_NAMES, ...this.options.classNames, ...overrides };
   }
 
   /**
    * Build complete field component
    */
-  buildField(name) {
+  buildField(name, classNames = this.resolveClassNames()) {
     const field = this.fields.get(name);
     if (!field) return null;
 
     const children = [
-      this.buildLabel(name),
-      this.buildInput(name)
+      this.buildLabel(name, classNames),
+      this.buildInput(name, classNames)
     ];
 
-    const error = this.buildError(name);
+    const error = this.buildError(name, classNames);
     if (error) {
       children.push(error);
     }
 
-    return {
-      div: {
-        className: 'form-field',
-        'data-field': name,
-        children
-      }
-    };
+    // data-field is the structural hook hydrateForm uses to find the wrapper,
+    // so classes stay entirely the consumer's to choose.
+    const props = { 'data-field': name, children };
+    if (classNames.field) props.className = classNames.field;
+
+    return { div: props };
   }
 
   /**
    * Build entire form
    */
   buildForm(options = {}) {
+    const settings = { ...this.options, ...options };
+    const classNames = this.resolveClassNames(options.classNames);
     const fields = [];
 
     for (const [name] of this.fields) {
-      fields.push(this.buildField(name));
+      // validate() has always skipped fields hidden by showWhen/showIf; render
+      // agreed with it only by accident, because nothing was ever hidden.
+      if (!this.isFieldVisible(name)) continue;
+      fields.push(this.buildField(name, classNames));
     }
 
-    const settings = { ...this.options, ...options };
-
     if (settings.submitButton !== false) {
-      fields.push({
-        button: {
-          type: 'submit',
-          text: settings.submitText || 'Submit',
-          className: 'submit-button'
-        }
-      });
+      const button = { type: 'submit', text: settings.submitText || 'Submit' };
+      if (classNames.submit) button.className = classNames.submit;
+      fields.push({ button });
     }
 
     const form = {};
 
-    // Emitted before the handler so the markup reads action-first, and so a
-    // form still submits to the right place without JavaScript.
     if (settings.action) form.action = settings.action;
     if (settings.method) form.method = settings.method;
     if (settings.name) form.name = settings.name;
@@ -541,8 +594,18 @@ export class FormBuilder {
     if (settings.className) form.className = settings.className;
     if (settings.enctype) form.enctype = settings.enctype;
 
-    form.onsubmit = 'handleSubmit(event)';
-    form.novalidate = true;
+    // Plain HTML by default: the form posts to `action` and the browser runs
+    // its own validation with JavaScript off. hydrateForm binds its own submit
+    // listener, so it never needed the inline handler this used to emit — and
+    // an inline handler breaks under a strict CSP besides.
+    if (settings.enhance) {
+      form.onsubmit = typeof settings.enhance === 'string'
+        ? settings.enhance
+        : 'handleSubmit(event)';
+    }
+
+    if (settings.novalidate === true) form.novalidate = true;
+
     form.children = fields;
 
     return { form };

--- a/packages/forms/src/form-builder.js
+++ b/packages/forms/src/form-builder.js
@@ -33,16 +33,31 @@ export const DEFAULT_CLASS_NAMES = {
  */
 const VALID_ATTRIBUTE_NAME = /^[A-Za-z_:][-A-Za-z0-9_:.]*$/;
 
+/**
+ * `onclick` and friends are syntactically valid names, and a string value
+ * renders as an inline handler — script execution from whatever produced the
+ * field config, and the thing this builder stopped emitting on the form
+ * itself. Handlers belong in hydration.
+ */
+const EVENT_HANDLER_NAME = /^on/i;
+
 function safeAttributes(attributes) {
   if (!attributes || typeof attributes !== 'object') return {};
 
   const safe = {};
   for (const [name, value] of Object.entries(attributes)) {
-    if (VALID_ATTRIBUTE_NAME.test(name)) {
-      safe[name] = value;
-    } else {
+    if (!VALID_ATTRIBUTE_NAME.test(name)) {
       console.warn(`[coherent.js/forms] Ignoring invalid attribute name: ${JSON.stringify(name)}`);
+      continue;
     }
+    if (EVENT_HANDLER_NAME.test(name)) {
+      console.warn(
+        `[coherent.js/forms] Ignoring inline event handler "${name}". ` +
+        'Attach handlers with hydrateForm instead.'
+      );
+      continue;
+    }
+    safe[name] = value;
   }
   return safe;
 }
@@ -325,12 +340,10 @@ export class FormBuilder {
   validate() {
     const errors = {};
 
-    for (const [name, field] of this.fields) {
-      // Skip hidden fields (support both showWhen and showIf)
-      const showCondition = field.showWhen || field.showIf;
-      if (showCondition && !showCondition(this.values)) {
-        continue;
-      }
+    for (const [name] of this.fields) {
+      // The same predicate buildForm() renders by, so a field that is not on
+      // the page can never block submission.
+      if (!this.isFieldVisible(name)) continue;
 
       const error = this.validateField(name);
       if (error) {
@@ -661,14 +674,18 @@ export class FormBuilder {
   isFieldVisible(name) {
     const field = this.fields.get(name);
     if (!field) return false;
-    
+
+    // visible:false wins outright — a showWhen that happens to return true
+    // must not resurrect a field the caller switched off.
+    if (field.visible === false) return false;
+
     // Support both showWhen and showIf
     const showCondition = field.showWhen || field.showIf;
     if (showCondition) {
       return showCondition(this.values);
     }
-    
-    return field.visible !== false;
+
+    return true;
   }
 
   /**

--- a/packages/forms/src/form-hydration.js
+++ b/packages/forms/src/form-hydration.js
@@ -8,6 +8,7 @@
  */
 
 import { validators } from './validators.js';
+import { DEFAULT_CLASS_NAMES } from './form-builder.js';
 
 /**
  * Hydrate a server-rendered form with client-side validation and behavior
@@ -38,7 +39,14 @@ export function hydrateForm(formSelector, options = {}) {
     validateOnSubmit: true,
     showErrorsOnTouch: true,
     debounce: 300,
-    ...options
+    ...options,
+    // Must match whatever the server rendered, so pass the same names given to
+    // buildForm's `classNames` when they were customised.
+    classNames: {
+      invalid: DEFAULT_CLASS_NAMES.invalid,
+      error: DEFAULT_CLASS_NAMES.error,
+      ...options.classNames
+    }
   };
 
   // Form state
@@ -109,12 +117,13 @@ export function hydrateForm(formSelector, options = {}) {
   function createErrorElement(name, inputElement) {
     const errorDiv = document.createElement('div');
     errorDiv.id = `${name}-error`;
-    errorDiv.className = 'error-message';
+    if (opts.classNames.error) errorDiv.className = opts.classNames.error;
     errorDiv.setAttribute('role', 'alert');
     errorDiv.style.display = 'none';
 
-    // Insert after input or its parent field wrapper
-    const fieldWrapper = inputElement.closest('.form-field') || inputElement.parentElement;
+    // Insert after input or its parent field wrapper. Keyed off data-field
+    // rather than a class, so consumers can name the wrapper what they like.
+    const fieldWrapper = inputElement.closest('[data-field]') || inputElement.parentElement;
     fieldWrapper.appendChild(errorDiv);
 
     return errorDiv;
@@ -204,13 +213,13 @@ export function hydrateForm(formSelector, options = {}) {
       errorElement.textContent = error;
       errorElement.style.display = 'block';
       element.setAttribute('aria-invalid', 'true');
-      element.classList.add('error');
+      if (opts.classNames.invalid) element.classList.add(opts.classNames.invalid);
     } else {
       // Hide error
       errorElement.textContent = '';
       errorElement.style.display = 'none';
       element.setAttribute('aria-invalid', 'false');
-      element.classList.remove('error');
+      if (opts.classNames.invalid) element.classList.remove(opts.classNames.invalid);
     }
   }
 

--- a/packages/forms/src/form-hydration.js
+++ b/packages/forms/src/form-hydration.js
@@ -200,6 +200,16 @@ export function hydrateForm(formSelector, options = {}) {
   }
 
   /**
+   * The invalid class as individual tokens.
+   *
+   * classList.add/remove take one token each — passing `'is-invalid has-error'`
+   * throws InvalidCharacterError.
+   */
+  function invalidClasses() {
+    return opts.classNames.invalid ? opts.classNames.invalid.trim().split(/\s+/) : [];
+  }
+
+  /**
    * Display error message
    */
   function displayError(name, error) {
@@ -213,13 +223,13 @@ export function hydrateForm(formSelector, options = {}) {
       errorElement.textContent = error;
       errorElement.style.display = 'block';
       element.setAttribute('aria-invalid', 'true');
-      if (opts.classNames.invalid) element.classList.add(opts.classNames.invalid);
+      invalidClasses().forEach(name => element.classList.add(name));
     } else {
       // Hide error
       errorElement.textContent = '';
       errorElement.style.display = 'none';
       element.setAttribute('aria-invalid', 'false');
-      if (opts.classNames.invalid) element.classList.remove(opts.classNames.invalid);
+      invalidClasses().forEach(name => element.classList.remove(name));
     }
   }
 

--- a/packages/forms/src/index.js
+++ b/packages/forms/src/index.js
@@ -7,7 +7,7 @@
  */
 
 // SERVER-SIDE: Build forms with validation metadata
-export { FormBuilder, createFormBuilder, buildForm } from './form-builder.js';
+export { FormBuilder, createFormBuilder, buildForm, DEFAULT_CLASS_NAMES } from './form-builder.js';
 
 // CLIENT-SIDE: Hydrate server-rendered forms
 export { hydrateForm } from './form-hydration.js';

--- a/packages/forms/test/form-markup.test.js
+++ b/packages/forms/test/form-markup.test.js
@@ -1,0 +1,229 @@
+/**
+ * Form markup tests
+ *
+ * Reported from a production marketing site whose contact form posts to its
+ * own origin so it works without JavaScript. The builder could not express it:
+ *
+ *  - every form carried `onsubmit="handleSubmit(event)"`, naming a global the
+ *    package never defines — hydrateForm binds its own listener — and
+ *    `novalidate`, which turns off the browser validation the no-JS path
+ *    depends on. `novalidate: false` was ignored;
+ *  - `attributes` was declared on FormField and read by nothing, so no
+ *    autocomplete and no maxlength;
+ *  - class names were hardcoded, so the site's CSS stopped applying, and
+ *    controls carried a literal `class=""`;
+ *  - fields hidden by `visible`/`showWhen` rendered anyway, which validate()
+ *    had always skipped.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render } from '@coherent.js/core';
+import { buildForm, createFormBuilder, DEFAULT_CLASS_NAMES } from '../src/index.js';
+
+const CONTACT = {
+  action: '/contact',
+  method: 'post',
+  className: 'contact-form',
+  classNames: {
+    field: 'contact-form__field',
+    control: 'contact-form__input',
+    submit: 'clk-btn clk-btn-primary',
+    error: 'contact-form__error'
+  },
+  fields: [
+    {
+      name: 'email',
+      type: 'email',
+      label: 'Email',
+      required: true,
+      attributes: { autocomplete: 'email', maxlength: 120 }
+    }
+  ]
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('no-JS submission', () => {
+  it('emits no inline onsubmit', () => {
+    const html = render(buildForm(CONTACT));
+
+    expect(html).not.toContain('onsubmit');
+    expect(html).not.toContain('handleSubmit');
+  });
+
+  it('leaves native validation on', () => {
+    expect(render(buildForm(CONTACT))).not.toContain('novalidate');
+  });
+
+  it('keeps the action and method a no-JS post needs', () => {
+    const html = render(buildForm(CONTACT));
+
+    expect(html).toContain('action="/contact"');
+    expect(html).toContain('method="post"');
+  });
+
+  it('emits novalidate only when asked', () => {
+    expect(render(buildForm({ ...CONTACT, novalidate: true }))).toContain('novalidate');
+    expect(render(buildForm({ ...CONTACT, novalidate: false }))).not.toContain('novalidate');
+  });
+
+  it('emits the inline handler only when enhancement is opted into', () => {
+    expect(render(buildForm({ ...CONTACT, enhance: true })))
+      .toContain('onsubmit="handleSubmit(event)"');
+  });
+
+  it('uses a custom enhancement handler verbatim', () => {
+    expect(render(buildForm({ ...CONTACT, enhance: 'contactSubmit(event)' })))
+      .toContain('onsubmit="contactSubmit(event)"');
+  });
+});
+
+describe('field attributes', () => {
+  it('passes attributes through to the control', () => {
+    const html = render(buildForm(CONTACT));
+
+    expect(html).toContain('autocomplete="email"');
+    expect(html).toContain('maxlength="120"');
+  });
+
+  it('honors disabled and readonly', () => {
+    const html = render(buildForm({
+      fields: [
+        { name: 'a', type: 'text', disabled: true },
+        { name: 'b', type: 'text', readonly: true }
+      ]
+    }));
+
+    expect(html).toContain('disabled');
+    expect(html).toContain('readonly');
+  });
+
+  it('cannot override the attributes the builder owns', () => {
+    const html = render(buildForm({
+      fields: [{
+        name: 'email',
+        type: 'email',
+        attributes: { name: 'hijacked', id: 'hijacked', type: 'hidden' }
+      }]
+    }));
+
+    expect(html).toContain('name="email"');
+    expect(html).toContain('id="email"');
+    expect(html).toContain('type="email"');
+    expect(html).not.toContain('hijacked');
+  });
+
+  // formatAttributes escapes attribute values but interpolates names raw.
+  it('drops attribute names that are not valid HTML names', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const html = render(buildForm({
+      fields: [{ name: 'q', type: 'text', attributes: { 'x onclick=alert(1)': 'y' } }]
+    }));
+
+    expect(html).not.toContain('onclick');
+    expect(warn).toHaveBeenCalled();
+  });
+});
+
+describe('class names', () => {
+  it('uses the configured names in place of the defaults', () => {
+    const html = render(buildForm(CONTACT));
+
+    expect(html).toContain('class="contact-form__field"');
+    expect(html).toContain('class="contact-form__input"');
+    expect(html).toContain('class="clk-btn clk-btn-primary"');
+    expect(html).not.toContain('form-field');
+    expect(html).not.toContain('submit-button');
+  });
+
+  it('appends a per-field class to the control class', () => {
+    const html = render(buildForm({
+      classNames: { control: 'base' },
+      fields: [{ name: 'q', type: 'text', className: 'extra' }]
+    }));
+
+    expect(html).toContain('class="base extra"');
+  });
+
+  it('falls back to the documented defaults', () => {
+    const html = render(buildForm({ fields: [{ name: 'q', type: 'text' }] }));
+
+    expect(html).toContain(`class="${DEFAULT_CLASS_NAMES.field}"`);
+    expect(html).toContain(`class="${DEFAULT_CLASS_NAMES.submit}"`);
+  });
+
+  it('never emits an empty class or placeholder attribute', () => {
+    const html = render(buildForm({ fields: [{ name: 'q', type: 'text' }] }));
+
+    expect(html).not.toContain('class=""');
+    expect(html).not.toContain('placeholder=""');
+  });
+
+  it('keeps the data-field hook hydration uses to find the wrapper', () => {
+    expect(render(buildForm(CONTACT))).toContain('data-field="email"');
+  });
+});
+
+describe('field visibility', () => {
+  it('omits a field marked not visible', () => {
+    const html = render(buildForm({
+      fields: [
+        { name: 'shown', type: 'text' },
+        { name: 'hidden', type: 'text', visible: false }
+      ]
+    }));
+
+    expect(html).toContain('name="shown"');
+    expect(html).not.toContain('name="hidden"');
+  });
+
+  it('renders and validates the same set of fields', () => {
+    const builder = createFormBuilder({
+      fields: [
+        { name: 'always', type: 'text', required: true },
+        { name: 'conditional', type: 'text', required: true, showWhen: () => false }
+      ]
+    });
+
+    const html = render(builder.buildForm());
+    const errors = builder.validate();
+
+    expect(html).not.toContain('name="conditional"');
+    expect(Object.keys(errors)).not.toContain('conditional');
+  });
+});
+
+// The reported form carries a trap field the server reads as spam signal.
+describe('honeypot', () => {
+  const builder = createFormBuilder({
+    action: '/contact',
+    method: 'post',
+    classNames: { control: 'contact-form__input' }
+  });
+  builder.field('email', { type: 'email', label: 'Email', required: true });
+  builder.field('website', {
+    type: 'text',
+    label: 'Website',
+    className: 'contact-form__trap',
+    attributes: { tabindex: '-1', autocomplete: 'off' }
+  });
+
+  const html = render(builder.buildForm());
+
+  it('renders the trap field with its hiding class', () => {
+    expect(html).toContain('name="website"');
+    expect(html).toContain('contact-form__trap');
+  });
+
+  it('keeps it out of the tab order and off autofill', () => {
+    expect(html).toContain('tabindex="-1"');
+    expect(html).toContain('autocomplete="off"');
+  });
+
+  it('does not require it', () => {
+    expect(builder.validate()).not.toHaveProperty('website');
+  });
+});

--- a/packages/forms/test/form-markup.test.js
+++ b/packages/forms/test/form-markup.test.js
@@ -115,6 +115,20 @@ describe('field attributes', () => {
     expect(html).not.toContain('hijacked');
   });
 
+  // Emitting these would reintroduce, per field, exactly the inline script
+  // this release stopped putting on the form element.
+  it.each(['onclick', 'onsubmit', 'ONERROR'])('refuses the inline handler %s', name => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const html = render(buildForm({
+      fields: [{ name: 'q', type: 'text', attributes: { [name]: 'alert(1)' } }]
+    }));
+
+    expect(html).not.toContain('alert(1)');
+    expect(html.toLowerCase()).not.toContain(name.toLowerCase());
+    expect(warn).toHaveBeenCalled();
+  });
+
   // formatAttributes escapes attribute values but interpolates names raw.
   it('drops attribute names that are not valid HTML names', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -178,6 +192,24 @@ describe('field visibility', () => {
 
     expect(html).toContain('name="shown"');
     expect(html).not.toContain('name="hidden"');
+  });
+
+  it('does not validate a field it did not render', () => {
+    const builder = createFormBuilder({
+      fields: [{ name: 'hidden', type: 'text', required: true, visible: false }]
+    });
+
+    expect(render(builder.buildForm())).not.toContain('name="hidden"');
+    expect(builder.validate()).toEqual({});
+  });
+
+  it('treats visible:false as final, even against a true showWhen', () => {
+    const builder = createFormBuilder({
+      fields: [{ name: 'q', type: 'text', visible: false, showWhen: () => true }]
+    });
+
+    expect(builder.isFieldVisible('q')).toBe(false);
+    expect(render(builder.buildForm())).not.toContain('name="q"');
   });
 
   it('renders and validates the same set of fields', () => {

--- a/packages/forms/test/hydration-classes.test.js
+++ b/packages/forms/test/hydration-classes.test.js
@@ -25,8 +25,14 @@ function element(tag, attributes = {}) {
     className: '',
     classList: {
       _set: new Set(),
-      add(name) { this._set.add(name); },
-      remove(name) { this._set.delete(name); },
+      // A real DOMTokenList throws on a token containing whitespace.
+      _assertToken(name) {
+        if (/\s/.test(name)) {
+          throw new Error(`InvalidCharacterError: ${JSON.stringify(name)}`);
+        }
+      },
+      add(name) { this._assertToken(name); this._set.add(name); },
+      remove(name) { this._assertToken(name); this._set.delete(name); },
       contains(name) { return this._set.has(name); }
     },
     value: '',
@@ -144,6 +150,27 @@ describe('error class names', () => {
     expect(created[0].className).toBe('contact-form__error');
     expect(input.classList.contains('is-invalid')).toBe(true);
     expect(input.classList.contains('error')).toBe(false);
+  });
+
+  // classList.add/remove take one token each — a space-separated value throws
+  // InvalidCharacterError in a real DOM.
+  it('applies a multi-token invalid class one token at a time', () => {
+    const { form, input } = formWithField('contact-form__field');
+
+    const controller = hydrateForm(form, {
+      classNames: { invalid: 'is-invalid has-error' }
+    });
+    controller.setTouched('email');
+    controller.validateField('email');
+
+    expect(input.classList.contains('is-invalid')).toBe(true);
+    expect(input.classList.contains('has-error')).toBe(true);
+
+    controller.setFieldValue('email', 'someone@example.com');
+    controller.validateField('email');
+
+    expect(input.classList.contains('is-invalid')).toBe(false);
+    expect(input.classList.contains('has-error')).toBe(false);
   });
 
   it('removes the configured invalid class once the field passes', () => {

--- a/packages/forms/test/hydration-classes.test.js
+++ b/packages/forms/test/hydration-classes.test.js
@@ -1,0 +1,162 @@
+/**
+ * Hydration class-contract tests
+ *
+ * The builder's class names are a live contract with hydrateForm, which used
+ * to hardcode them: it found the field wrapper with `.form-field` and wrote
+ * `.error-message` / `.error`. Making the builder's names configurable without
+ * moving hydration onto the `data-field` attribute would have broken error
+ * display for anyone who renamed them.
+ *
+ * The forms package runs in the `node` environment, so this drives hydrateForm
+ * against a DOM double covering only what error rendering touches.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { hydrateForm } from '../src/form-hydration.js';
+
+function element(tag, attributes = {}) {
+  const node = {
+    tagName: tag.toUpperCase(),
+    attributes: { ...attributes },
+    dataset: {},
+    style: {},
+    children: [],
+    parentElement: null,
+    className: '',
+    classList: {
+      _set: new Set(),
+      add(name) { this._set.add(name); },
+      remove(name) { this._set.delete(name); },
+      contains(name) { return this._set.has(name); }
+    },
+    value: '',
+    get type() { return node.attributes.type ?? 'text'; },
+    getAttribute: name => node.attributes[name] ?? null,
+    setAttribute: (name, value) => { node.attributes[name] = String(value); },
+    hasAttribute: name => name in node.attributes,
+    addEventListener() {},
+    removeEventListener() {},
+    appendChild(child) {
+      child.parentElement = node;
+      node.children.push(child);
+      return child;
+    },
+    // Walk up until an ancestor matches `[attribute]` or `.class`
+    closest(selector) {
+      const attribute = selector.match(/^\[([^\]]+)\]$/)?.[1];
+      const className = selector.startsWith('.') ? selector.slice(1) : null;
+
+      for (let current = node; current; current = current.parentElement) {
+        if (attribute && attribute in current.attributes) return current;
+        if (className && current.className.split(' ').includes(className)) return current;
+      }
+      return null;
+    },
+    querySelectorAll: () => [],
+    querySelector: () => null
+  };
+  return node;
+}
+
+/** A wrapper carrying `data-field` plus a custom class, with one input. */
+function formWithField(wrapperClass) {
+  const input = element('input', { name: 'email', type: 'email', required: '' });
+  const wrapper = element('div', { 'data-field': 'email' });
+  wrapper.className = wrapperClass;
+  wrapper.appendChild(input);
+
+  const form = element('form');
+  form.appendChild(wrapper);
+  form.querySelectorAll = selector => (selector === '[name]' ? [input] : []);
+
+  return { form, wrapper, input };
+}
+
+let created;
+
+beforeEach(() => {
+  created = [];
+  global.document = {
+    createElement: tag => {
+      const node = element(tag);
+      created.push(node);
+      return node;
+    },
+    getElementById: () => null,
+    querySelector: () => null
+  };
+});
+
+afterEach(() => {
+  delete global.document;
+  vi.restoreAllMocks();
+});
+
+describe('finding the field wrapper', () => {
+  it('uses data-field rather than a class name', () => {
+    const { form, wrapper } = formWithField('contact-form__field');
+
+    hydrateForm(form);
+
+    expect(created).toHaveLength(1);
+    expect(created[0].parentElement).toBe(wrapper);
+  });
+
+  it('still works for hand-written markup with no data-field', () => {
+    const input = element('input', { name: 'email' });
+    const wrapper = element('div');
+    wrapper.className = 'form-field';
+    wrapper.appendChild(input);
+
+    const form = element('form');
+    form.appendChild(wrapper);
+    form.querySelectorAll = selector => (selector === '[name]' ? [input] : []);
+
+    hydrateForm(form);
+
+    // No data-field to match, so the parentElement fallback applies — which
+    // for the standard structure is the same wrapper.
+    expect(created[0].parentElement).toBe(wrapper);
+  });
+});
+
+describe('error class names', () => {
+  it('defaults to the framework names', () => {
+    const { form, input } = formWithField('form-field');
+
+    const controller = hydrateForm(form);
+    controller.setTouched('email');
+    controller.validateField('email');
+
+    expect(created[0].className).toBe('error-message');
+    expect(input.classList.contains('error')).toBe(true);
+  });
+
+  it('writes the configured names instead', () => {
+    const { form, input } = formWithField('contact-form__field');
+
+    const controller = hydrateForm(form, {
+      classNames: { error: 'contact-form__error', invalid: 'is-invalid' }
+    });
+    controller.setTouched('email');
+    controller.validateField('email');
+
+    expect(created[0].className).toBe('contact-form__error');
+    expect(input.classList.contains('is-invalid')).toBe(true);
+    expect(input.classList.contains('error')).toBe(false);
+  });
+
+  it('removes the configured invalid class once the field passes', () => {
+    const { form, input } = formWithField('contact-form__field');
+
+    const controller = hydrateForm(form, { classNames: { invalid: 'is-invalid' } });
+    controller.setTouched('email');
+    controller.validateField('email');
+    expect(input.classList.contains('is-invalid')).toBe(true);
+
+    controller.setFieldValue('email', 'someone@example.com');
+    controller.validateField('email');
+
+    expect(input.classList.contains('is-invalid')).toBe(false);
+  });
+});

--- a/packages/forms/types/index.d.ts
+++ b/packages/forms/types/index.d.ts
@@ -58,6 +58,10 @@ export interface FormField<T = unknown> {
   placeholder?: string;
   /** Whether field is required */
   required?: boolean;
+  /** Render the field; `false` omits it from the built form */
+  visible?: boolean;
+  /** Render the field only when this returns true for the current values */
+  showWhen?: (values: Record<string, unknown>) => boolean;
   /** Whether field is disabled */
   disabled?: boolean;
   /** Whether field is readonly */
@@ -72,8 +76,17 @@ export interface FormField<T = unknown> {
   validators?: Validator[];
   /** Field-specific validation configuration */
   validation?: FieldValidation<T>;
-  /** Additional HTML attributes */
+  /**
+   * Extra attributes on the control, for things the field config has no
+   * dedicated option for — `autocomplete`, `maxlength`, `tabindex`, `data-*`.
+   *
+   * Applied before the builder's own attributes, so `name`, `id`, `type` and
+   * the `aria-*` pair cannot be overridden. Names that are not valid HTML
+   * attribute names are dropped with a warning.
+   */
   attributes?: Record<string, unknown>;
+  /** Class on the control, appended to `classNames.control` */
+  className?: string;
   /** Transform function to convert raw input to typed value */
   transform?: (value: unknown) => T;
 }
@@ -110,6 +123,28 @@ export interface FieldValidation<T = unknown> {
 // ============================================================================
 
 /**
+ * Class applied to each structural slot of a built form.
+ *
+ * The wrapper is found by hydration through its `data-field` attribute, not
+ * its class, so every one of these is free for the consumer to choose.
+ */
+export interface FormClassNames {
+  /** Wrapper around label, control and error */
+  field: string;
+  label: string;
+  /** Base class on the control, before any per-field `className` */
+  control: string;
+  /** Added to the control while it has a visible error */
+  invalid: string;
+  /** The error message element */
+  error: string;
+  submit: string;
+}
+
+/** The class names a form uses when `classNames` does not override them. */
+export const DEFAULT_CLASS_NAMES: FormClassNames;
+
+/**
  * Form configuration options
  */
 export interface FormConfig {
@@ -129,8 +164,20 @@ export interface FormConfig {
   onSubmit?: (data: Record<string, unknown>) => void | Promise<void>;
   /** Form encoding type */
   enctype?: 'application/x-www-form-urlencoded' | 'multipart/form-data' | 'text/plain';
-  /** Whether to disable browser validation */
+  /**
+   * Emit `novalidate`, turning off the browser's own validation. Defaults to
+   * `false` — leaving native validation working with JavaScript disabled.
+   */
   novalidate?: boolean;
+  /**
+   * Emit an inline `onsubmit` handler. `true` uses `handleSubmit(event)`; a
+   * string is used verbatim. Off by default, so the form submits natively —
+   * {@link hydrateForm} binds its own listener and needs nothing inline, and
+   * an inline handler is blocked by a strict CSP.
+   */
+  enhance?: boolean | string;
+  /** Class names for each structural slot; see {@link DEFAULT_CLASS_NAMES} */
+  classNames?: Partial<FormClassNames>;
   /** Form ID */
   id?: string;
   /** Validate a field as it changes; defaults to `true` */
@@ -220,8 +267,17 @@ export class FormBuilder<T extends Record<string, unknown> = Record<string, unkn
   /** The built form, rendered to an HTML string */
   toHTML(options?: FormConfig): string;
 
+  /** Merge configured class names over {@link DEFAULT_CLASS_NAMES} */
+  resolveClassNames(overrides?: Partial<FormClassNames>): FormClassNames;
+
   /** Build the node for one field, including its label and error */
-  buildField(name: keyof T & string): CoherentNode;
+  buildField(name: keyof T & string, classNames?: FormClassNames): CoherentNode;
+  /** Build one field's control */
+  buildInput(name: keyof T & string, classNames?: FormClassNames): CoherentNode | null;
+  /** Build one field's label */
+  buildLabel(name: keyof T & string, classNames?: FormClassNames): CoherentNode | null;
+  /** Build one field's error message, or `null` when it has none to show */
+  buildError(name: keyof T & string, classNames?: FormClassNames): CoherentNode | null;
 
   /** Copy of the current values */
   serialize(): Partial<T>;
@@ -265,6 +321,12 @@ export interface HydrationOptions {
   showErrorsOnTouch?: boolean;
   /** Debounce window for change validation, in ms; defaults to `300` */
   debounce?: number;
+  /**
+   * Class names the client writes. Pass the same `invalid` and `error` given
+   * to {@link buildForm}, or the classes added on failure will not match what
+   * the server rendered.
+   */
+  classNames?: Partial<Pick<FormClassNames, 'invalid' | 'error'>>;
   /**
    * Called instead of the browser's native submit. Return `false` to cancel,
    * or a promise to defer completion.

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -30,7 +30,7 @@
     "typecheck": "tsc -p tsconfig.typecheck.json --noEmit"
   },
   "peerDependencies": {
-    "@coherent.js/core": "workspace:*"
+    "@coherent.js/core": "workspace:^"
   },
   "repository": {
     "type": "git",

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -58,7 +58,7 @@
     "fastify-plugin": "^6.0.0"
   },
   "peerDependencies": {
-    "@coherent.js/core": "workspace:*",
+    "@coherent.js/core": "workspace:^",
     "@remix-run/server-runtime": ">=2.0.0",
     "@sveltejs/kit": ">=2.0.0",
     "astro": ">=4.0.0",

--- a/packages/seo/package.json
+++ b/packages/seo/package.json
@@ -30,7 +30,7 @@
     "typecheck": "tsc -p tsconfig.typecheck.json --noEmit"
   },
   "peerDependencies": {
-    "@coherent.js/core": "workspace:*"
+    "@coherent.js/core": "workspace:^"
   },
   "repository": {
     "type": "git",

--- a/packages/state/package.json
+++ b/packages/state/package.json
@@ -54,7 +54,7 @@
     "typecheck": "tsc -p tsconfig.typecheck.json --noEmit"
   },
   "peerDependencies": {
-    "@coherent.js/core": "workspace:*"
+    "@coherent.js/core": "workspace:^"
   },
   "types": "./types/index.d.ts",
   "files": [

--- a/packages/tooling/package.json
+++ b/packages/tooling/package.json
@@ -74,7 +74,7 @@
     "url": "https://github.com/Tomdrouv1/coherent.js/issues"
   },
   "peerDependencies": {
-    "@coherent.js/core": "workspace:*"
+    "@coherent.js/core": "workspace:^"
   },
   "dependencies": {
     "typescript": "^5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,24 +10,24 @@ overrides:
   vite@>=7.0.0 <8.0.0: ^7.3.2
   fastify: ^5.8.5
   find-my-way@<9.6.1: ^9.7.0
-  fast-uri@>=3.0.0 <3.1.4: ^3.1.4
+  fast-uri@>=3.0.0 <3.1.5: ^3.1.5
   tmp: ^0.2.6
   '@remix-run/server-runtime': ^2.17.5
   turbo-stream: ^3.0.0
   undici@<6.27.0: ^6.27.0
-  undici@>=7.0.0 <7.28.0: ^7.28.0
+  undici@>=7.0.0 <7.29.0: ^7.29.0
   astro@>=4.0.0 <7.0.10: ^7.1.6
   form-data@>=4.0.0 <4.0.6: ^4.0.6
   ws@>=8.0.0 <8.21.0: ^8.21.0
   qs@>=6.11.1 <6.15.2: ^6.15.2
   postcss@>=8.0.0 <8.5.18: ^8.5.18
-  ip-address@<=10.1.0: ^10.1.1
+  ip-address@<=10.3.0: ^10.3.1
   js-yaml@<3.15.0: ^3.15.0
   esbuild@>=0.27.3 <0.28.1: ^0.28.1
   webpack@>=5.49.0 <5.104.1: ^5.104.1
   cookie@<0.7.0: ^0.7.0
   '@tootallnate/once@<2.0.1': ^2.0.1
-  brace-expansion@<5.0.8: ^5.0.8
+  brace-expansion@<5.0.9: ^5.0.9
   svgo@>=4.0.0 <4.0.2: ^4.0.2
   linkify-it@<5.0.2: ^5.0.2
   body-parser@>=2.0.0 <2.3.0: ^2.3.0
@@ -2279,8 +2279,8 @@ packages:
   boundary@2.0.0:
     resolution: {integrity: sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -2901,8 +2901,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -3249,8 +3249,8 @@ packages:
     resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+  ip-address@10.4.0:
+    resolution: {integrity: sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -4914,8 +4914,8 @@ packages:
     resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.1.0:
@@ -6071,7 +6071,7 @@ snapshots:
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
 
   '@fastify/error@4.2.0': {}
 
@@ -7154,7 +7154,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -7372,7 +7372,7 @@ snapshots:
 
   boundary@2.0.0: {}
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -7482,7 +7482,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.28.0
+      undici: 7.29.0
       whatwg-mimetype: 4.0.0
 
   chokidar@5.0.0:
@@ -7990,7 +7990,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
@@ -8006,7 +8006,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:
@@ -8444,7 +8444,7 @@ snapshots:
 
   ini@6.0.0: {}
 
-  ip-address@10.2.0:
+  ip-address@10.4.0:
     optional: true
 
   ipaddr.js@1.9.1: {}
@@ -8878,11 +8878,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
     optional: true
 
   minimist@1.2.8: {}
@@ -9823,7 +9823,7 @@ snapshots:
 
   socks@2.8.7:
     dependencies:
-      ip-address: 10.2.0
+      ip-address: 10.4.0
       smart-buffer: 4.2.0
     optional: true
 
@@ -10166,7 +10166,7 @@ snapshots:
 
   undici@6.27.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unicorn-magic@0.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,7 +55,7 @@ importers:
         version: 6.21.0(socks@2.8.7)
       mysql2:
         specifier: '>=3.0.0 < 4.0.0'
-        version: 3.20.0(@types/node@26.1.1)
+        version: 3.20.0(@types/node@26.1.2)
       pg:
         specifier: '>=8.8.0 < 9.0.0'
         version: 8.20.0
@@ -160,7 +160,7 @@ importers:
   packages/api:
     dependencies:
       '@coherent.js/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
     devDependencies:
       '@coherent.js/state':
@@ -211,7 +211,7 @@ importers:
   packages/database:
     dependencies:
       '@coherent.js/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       sqlite3:
         specifier: '>=5.0.0'
@@ -220,28 +220,28 @@ importers:
   packages/devtools:
     dependencies:
       '@coherent.js/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
 
   packages/forms:
     dependencies:
       '@coherent.js/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@coherent.js/state':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../state
 
   packages/i18n:
     dependencies:
       '@coherent.js/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
 
   packages/integrations:
     dependencies:
       '@coherent.js/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       '@remix-run/server-runtime':
         specifier: ^2.17.5
@@ -274,19 +274,19 @@ importers:
   packages/seo:
     dependencies:
       '@coherent.js/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
 
   packages/state:
     dependencies:
       '@coherent.js/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
 
   packages/tooling:
     dependencies:
       '@coherent.js/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
       typescript:
         specifier: ^5.9.3
@@ -8972,9 +8972,9 @@ snapshots:
 
   mute-stream@0.0.8: {}
 
-  mysql2@3.20.0(@types/node@26.1.1):
+  mysql2@3.20.0(@types/node@26.1.2):
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 26.1.2
       aws-ssl-profiles: 1.1.2
       denque: 2.1.0
       generate-function: 2.3.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,8 +32,8 @@ overrides:
   fastify: '^5.8.5'
   # find-my-way HTTP/2 DDoS — 9.6.1 was never published, 9.7.0 is the first fix.
   'find-my-way@<9.6.1': '^9.7.0'
-  # fast-uri ReDoS and host confusion via IDN/backslash — fixed in 3.1.4.
-  'fast-uri@>=3.0.0 <3.1.4': '^3.1.4'
+  # fast-uri ReDoS and host confusion via IDN/backslash — fixed in 3.1.5.
+  'fast-uri@>=3.0.0 <3.1.5': '^3.1.5'
   # tmp arbitrary write via symlink — fixed in 0.2.6.
   tmp: '^0.2.6'
   # @remix-run/server-runtime advisory — fixed in 2.17.5 (stays on major 2).
@@ -43,7 +43,7 @@ overrides:
   # undici TLS-validation bypass, WebSocket DoS, cross-origin routing —
   # fixed in 6.27.0 (6.x line, via @codecov/vite-plugin) and 7.28.0 (7.x).
   'undici@<6.27.0': '^6.27.0'
-  'undici@>=7.0.0 <7.28.0': '^7.28.0'
+  'undici@>=7.0.0 <7.29.0': '^7.29.0'
   # astro SSRF and three XSS advisories — only fixed on 7.x, within the
   # `>=4.0.0` optional-peer range. Needs Node >=22.12.
   'astro@>=4.0.0 <7.0.10': '^7.1.6'
@@ -55,8 +55,9 @@ overrides:
   'qs@>=6.11.1 <6.15.2': '^6.15.2'
   # postcss XSS via unescaped </style> and source-map path traversal — 8.5.18.
   'postcss@>=8.0.0 <8.5.18': '^8.5.18'
-  # ip-address XSS in Address6 HTML-emitting methods — fixed in 10.1.1.
-  'ip-address@<=10.1.0': '^10.1.1'
+  # ip-address XSS in Address6, and Address4 decoding leading-zero octets as
+  # decimal — fixed in 10.3.1.
+  'ip-address@<=10.3.0': '^10.3.1'
   # js-yaml quadratic-complexity DoS in merge-key handling — fixed in 3.15.0
   # (scoped to the 3.x line so js-yaml 4 consumers are untouched).
   'js-yaml@<3.15.0': '^3.15.0'
@@ -71,7 +72,7 @@ overrides:
   '@tootallnate/once@<2.0.1': '^2.0.1'
   # brace-expansion unbounded expansion DoS — no 1.x backport, and 5.0.8 still
   # ships a CommonJS entry, so minimatch@3 keeps working.
-  'brace-expansion@<5.0.8': '^5.0.8'
+  'brace-expansion@<5.0.9': '^5.0.9'
   # svgo removeScripts left executable script content in place — fixed in 4.0.2.
   'svgo@>=4.0.0 <4.0.2': '^4.0.2'
   # linkify-it quadratic-complexity DoS on `mailto:` links — fixed in 5.0.2.


### PR DESCRIPTION
Reported from a production marketing site whose contact form posts to its own origin so it works with JavaScript off. The builder could not express it. Four issues, and the first is the serious one.

## 1. Forms only worked with JavaScript

Every form carried `onsubmit="handleSubmit(event)"` and `novalidate`, and `novalidate: false` was ignored.

Worth being precise about the handler: it names a global the package **never defines**. `hydrateForm` binds its own listener with a *local* function (`form-hydration.js:276,356`). So the attribute was vestigial — it errored in the console, and a strict CSP blocked it, which the comment above `buildInput()` explicitly claims to avoid. `novalidate` meanwhile disabled the browser validation a no-JS submission depends on.

Both are now off by default. The form posts to its `action` and validates natively:

```html
<form action="/contact" method="post" name="form" class="contact-form">
```

Opt back in with `enhance: true` (or a handler string) and `novalidate: true`.

**This was not a 1.0.1 regression** — it has been there since 1.0.0 (`form-builder.js:508` on the `v1.0.0` tag). What 1.0.1 changed is that `buildForm()` started working, so the markup became reachable. `novalidate: false` being ignored *is* a 1.0.1 gap: that release added plumbing for `action`/`method`/`name`/`id`/`className`/`enctype` and left `novalidate` hardcoded.

## 2. `attributes` was ignored

Declared on `FormField`, read by nothing. Now applied — **before** the builder’s own props, so `name`, `id`, `type` and the `aria-*` pair cannot be overridden. `disabled` and `readonly` are honoured too.

Attribute names are validated against `/^[A-Za-z_:][-A-Za-z0-9_:.]*$/`: `formatAttributes` escapes attribute *values* but interpolates *names* raw, so a newly-exposed passthrough needs the guard.

## 3. Class names were hardcoded

A `classNames` option covers wrapper, label, control, invalid state, error message and submit button, defaulting to the previous values and exported as `DEFAULT_CLASS_NAMES`. Per-field `className` appends to the control class.

The non-obvious part: **those names were a live contract with hydration**, which found the wrapper via `.form-field` and wrote `.error-message` / `.error`. Making them configurable without addressing that would have broken error display. `hydrateForm` now keys off the `data-field` attribute the builder already emitted, and accepts the same `classNames`.

## 4. Honeypot

Falls out of 2 and 3 rather than needing an API:

```js
builder.field(website, {
  label: Website,
  className: contact-form__trap,
  attributes: { tabindex: -1, autocomplete: off }
});
```

## Also found

`buildForm()` ignored `visible: false` and `showWhen` while `validate()` honoured them — so a conditionally hidden field rendered but was never validated. Both now agree. Controls no longer carry an empty `class=""` or `placeholder=""`.

## Changesets: `fixed` → `linked`

This one is worth your attention. `changeset status` resolved this **minor** changeset to **`2.0.0`**:

| bump | with `fixed` | expected |
|---|---|---|
| patch | `1.0.2` ✅ | `1.0.2` |
| **minor** | **`2.0.0`** ❌ | **`1.1.0`** |
| major | `2.0.0` ✅ | `2.0.0` |

Bisected to `fixed: [["@coherent.js/*"]]` on @changesets/cli 2.31.1 — with `fixed: []` the same file resolves to `1.1.0`. Patch and major are unaffected, which is why 1.0.0 and 1.0.1 never exposed it. Releasing the way 1.0.1 was released would have published **`2.0.0` across all twelve packages**, immutably.

`linked` produces the correct `1.1.0`. Trade-off: unchanged packages no longer move in lockstep, so this release bumps `forms` alone and leaves the other eleven at `1.0.1`.

## Verification

The tests are real regression tests — against the current `main` they fail **14 of 20** (markup) and **2 of 3** (hydration class contract), verified by swapping the pre-fix sources back in.

The forms package runs in the `node` environment and has no e2e form coverage, so the hydration contract is tested against a small DOM double rather than by adding jsdom — flagging that it is not a browser-level test.

Build, lint, typecheck across 12 packages, 1848 tests, and the api-surface / type-surface / bundle-size gates. Both forms baselines regenerated (new `DEFAULT_CLASS_NAMES` export; bundle +7%); only that package’s, since the others were unrelated drift.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Forms now support no-JavaScript submission with native validation and opt-in enhancement
  * Configurable class names for form elements
  * Support for custom attributes, disabled/readonly controls, and honeypot fields
  * CSP-safe output generation

* **Tests**
  * Added comprehensive form markup and hydration tests

* **Chores**
  * Updated configuration and type definitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->