### PR TITLE
ci(security): run the audit on main, on a schedule, and on every PR

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,11 +1,19 @@
 name: Security Checks
 
+# An audit result depends on the advisory database as much as on the lockfile,
+# so it goes stale on its own. Filtering by path meant this only ran when a PR
+# happened to touch a manifest: 28 advisories, one of them critical, built up
+# unnoticed while main stayed green, and were found only because an unrelated
+# PR added a script to five package.json files.
 on:
   pull_request:
     branches: [main]
-    paths:
-      - '**/package.json'
-      - 'pnpm-lock.yaml'
+  push:
+    branches: [main]
+  # New advisories land against a lockfile nobody touched.
+  schedule:
+    - cron: '17 3 * * *'
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
The security audit only ran on pull requests that touched a `package.json` or the lockfile, and **never on `main`**. That is the wrong shape for this check.

## Why the path filter was the defect

An audit result depends on the **advisory database** as much as on the files. It goes stale on its own, with nothing in the repo changing.

That is not hypothetical — it happened twice this week:

- **28 advisories, one critical** (`tar` decompression DoS) accumulated while `main` showed green. They surfaced only because an unrelated PR happened to add a `typecheck` script to five `package.json` files, which tripped the path filter by accident.
- A day later, **four more** (`undici`, `fast-uri`, `ip-address`, `brace-expansion`) appeared against a lockfile nobody had edited.

Scheduled runs are the only trigger that catches the second case at all.

## Changes

```yaml
on:
  pull_request:
    branches: [main]     # path filter removed
  push:
    branches: [main]     # default branch now carries a real signal
  schedule:
    - cron: "17 3 * * *" # new advisories against an untouched lockfile
  workflow_dispatch:     # on demand
```

The `pull_request` path filter is dropped for the same reason: a PR that does not touch a manifest can still be merged into a tree with unpatched advisories. The job runs in well under a minute, so making it unconditional costs little.

Cron is at `03:17` rather than the top of the hour, where GitHub’s scheduled-run queue is busiest and starts get delayed.

## Notes

- `contents: read` is already the only permission, which is all a scheduled run needs.
- `pnpm install --frozen-lockfile` means the schedule audits exactly the committed lockfile — the tree that actually ships.
- A scheduled failure shows up as a failed run on `main`. If you would rather it opened an issue or notified elsewhere, that is a small follow-up; I did not add it since it is a notification-policy call.
- `actionlint` runs on this PR through the existing `validate-workflows` job, since it touches `.github/workflows/**`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Security checks now run on pushes to the main branch, daily on a schedule, and when manually triggered.
  * Security checks run for all pull requests, regardless of which files changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->